### PR TITLE
タスク一覧画面にタスクのステータスを表示させます

### DIFF
--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -7,6 +7,7 @@ table
       td
         = link_to task.title, task
       td = task.due_at
+      td = task.status
       td = task.priority
       td
         = link_to "編集", edit_task_path(task.id)

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -2,16 +2,17 @@
   = content_tag(:div, value, class: key)
 
 table
+  tr
+    th タスク名
+    th 期限
+    th ステータス
+    th 優先度
   - @tasks.each do |task|
     tr
-      td
-        = link_to task.title, task
+      td = link_to task.title, task
       td = task.due_at
       td = task.status
       td = task.priority
-      td
-        = link_to "編集", edit_task_path(task.id)
-      td
-        = link_to "削除", task, method: :delete, data: {confirm: "本当に削除しますか？"}
-div
-  = link_to "タスクを追加", new_task_path
+      td = link_to "編集", edit_task_path(task.id)
+      td = link_to "削除", task, method: :delete, data: {confirm: "本当に削除しますか？"}
+div = link_to "タスクを追加", new_task_path


### PR DESCRIPTION
## 何をやったか
[タスクの一覧を表示できるようにした](https://github.com/tsumichan/todo-app/pull/10)ときに
ステータスを表示させるのを忘れていたため、追加しました。

また、各項目のタイトルを追加し、ちょっと見やすくなりました！ 🎉 


:point_down:**こうなりました**
![image](https://user-images.githubusercontent.com/14156156/42075071-19dcd20e-7baa-11e8-8654-737ce68f241c.png)


## レビューポイント

- 余計なインデント、スペースがないか
- ステータスを表示する処理が正しく書けているかどうか
- 無駄な記述の仕方をしていないか

## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:
