### PR TITLE
Rspecの設定を変更します

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,6 @@ jobs:
             TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
 
             bundle exec rspec --format progress \
-                            --format RspecJunitFormatter \
                             --out /tmp/test-results/rspec.xml \
                             --format progress \
                             $TEST_FILES

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,1 @@
 --require spec_helper
---format RspecJunitFormatter
---out rspec.xml

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ group :development, :test do
   gem 'pry-doc'
   gem 'rspec-rails'
   gem 'factory_bot_rails'
-  gem "rspec_junit_formatter"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,8 +179,6 @@ GEM
       rspec-mocks (~> 3.7.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    rspec_junit_formatter (0.4.1)
-      rspec-core (>= 2, < 4, != 2.12.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.1)
     sass (3.5.6)
@@ -262,7 +260,6 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.0)
   rspec-rails
-  rspec_junit_formatter
   sass-rails (~> 5.0)
   selenium-webdriver
   slim-rails


### PR DESCRIPTION
## 何をやったか
RspecJunitFormatterが思ったより微妙だったので、使うのをやめます。

## レビューポイント

- 余計なインデント、スペースがないか
- RspecJunitFormatterを使わないようにする処理が正しく書けているかどうか
- 無駄な記述の仕方をしていないか

## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:


## 追記
### 微妙だったところ

- RspecJunitFormatterを使うと、テストスイートが`rspec.xml`に出力される
- 使わないときよりも文字の量や情報量が増えて、ぱっと見て見にくいな〜と感じた
- RspecJunitFormatterを使わなくても成功・失敗、エラーの詳細が見れるので、必要性を感じなくなった
