### PR TITLE
タスク一覧を作成日時順に並び替える

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.order(created_at: :desk)
+    @tasks = Task.order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.order(created_at: 'DESC')
+    @tasks = Task.order(created_at: :desk)
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.order(created_at: 'DESC')
   end
 
   def new

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -62,4 +62,15 @@ describe 'タスク' do
       expect(page).to have_content I18n.t('view.task.message.deleted')
     end
   end
+
+  context 'タスクが作成日時の降順で表示される' do
+    let! (:new_task) { create(:task, created_at: '2020-01-01') }
+    let! (:old_task) { create(:task, created_at: '2000-01-01') }
+
+    it 'タスクを降順でソートする' do
+      visit tasks_path
+      page.all('tr')[1].has_link?('編集', href: '/tasks/#{new_task.id}/edit')
+      page.all('tr')[2].has_link?('編集', href: '/tasks/#{old_task.id}/edit')
+    end
+  end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -6,7 +6,7 @@ describe 'タスク' do
 
   context '新規のタスクを作成する' do
     it '作成する' do
-      visit '/tasks/new'
+      visit new_task_path
       fill_in I18n.t('view.task.label.title'), with: title
       fill_in I18n.t('view.task.label.description'), with: 'テスト用タスクです'
       fill_in I18n.t('view.task.label.due_at'), with: '2020-01-01 00:00:00'
@@ -18,7 +18,7 @@ describe 'タスク' do
     end
 
     it '作成完了のフラッシュメッセージが表示される' do
-      visit '/tasks/new'
+      visit new_task_path
       fill_in I18n.t('view.task.label.title'), with: title
       fill_in I18n.t('view.task.label.description'), with: 'テスト用タスクです'
       fill_in I18n.t('view.task.label.due_at'), with: '2020-01-01 00:00:00'
@@ -50,14 +50,14 @@ describe 'タスク' do
   context '既存のタスクを削除する' do
     let!(:task) { create(:task) }
     it '削除する' do
-      visit '/tasks'
+      visit tasks_path
       click_link I18n.t('view.task.link_text.delete')
       expect(Task.exists?(title: title)).not_to be true
       expect(page).not_to have_content title
     end
 
     it '削除完了のフラッシュメッセージが表示される' do
-      visit '/tasks'
+      visit tasks_path
       click_link I18n.t('view.task.link_text.delete')
       expect(page).to have_content I18n.t('view.task.message.deleted')
     end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -69,8 +69,9 @@ describe 'タスク' do
 
     it 'タスクを降順でソートする' do
       visit tasks_path
-      page.all('tr')[1].has_link?('編集', href: '/tasks/#{new_task.id}/edit')
-      page.all('tr')[2].has_link?('編集', href: '/tasks/#{old_task.id}/edit')
+      expect(page.all('tr')[1]).to have_link('編集', href: edit_task_path(new_task.id))
+      expect(page.all('tr')[2]).to have_link('編集', href: edit_task_path(old_task.id))
+
     end
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -66,12 +66,10 @@ describe 'タスク' do
   context 'タスクが作成日時の降順で表示される' do
     let! (:new_task) { create(:task, created_at: '2020-01-01') }
     let! (:old_task) { create(:task, created_at: '2000-01-01') }
-
     it 'タスクを降順でソートする' do
       visit tasks_path
       expect(page.all('tr')[1]).to have_link('編集', href: edit_task_path(new_task.id))
       expect(page.all('tr')[2]).to have_link('編集', href: edit_task_path(old_task.id))
-
     end
   end
 end


### PR DESCRIPTION
## 何をやったか
タスク一覧を作成日時順（上から新しい順）に並び替えました（[ステップ11](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9711-%E3%82%BF%E3%82%B9%E3%82%AF%E4%B8%80%E8%A6%A7%E3%82%92%E4%BD%9C%E6%88%90%E6%97%A5%E6%99%82%E3%81%AE%E9%A0%86%E7%95%AA%E3%81%A7%E4%B8%A6%E3%81%B3%E6%9B%BF%E3%81%88%E3%82%88%E3%81%86)）

## レビューポイント

- 余計なインデント、スペースがないか
- タスク一覧を作成日時順に並び替える処理が正しく書けているかどうか
- 無駄な記述の仕方をしていないか

## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:
