### PR TITLE
Taskモデルのバリデーションを追加

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,4 @@
 class Task < ApplicationRecord
+  validates :title, presence: true, length: { maximum: 100 }
+  validates :description, length: { maximum: 255 }
 end

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -1,3 +1,9 @@
+- if @task.errors.any?
+  div
+    ul
+      - @task.errors.full_messages.each do |message|
+        li = message
+
 = form_for @task do |f|
   div
     = f.label :title, t('view.task.label.title')


### PR DESCRIPTION
## 何をやったか
Taskモデルにバリデーションを追加しました。
具体的には↓

- タスクのタイトルが空欄のままだとタスクを作成（保存）できないようにした
- タスクのタイトルは100文字まで
- タスクの説明文は255文字まで

## レビューポイント

- 余計なインデント、スペースがないか
- Taskモデルのバリデーションの処理が正しく書けているかどうか
- 無駄な記述の仕方をしていないか

## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:
