### PR TITLE
タスクを終了期限が近い順でソートできるようにした

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,11 +2,11 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    if params[:sort_by] == 'due_at'
-      @tasks = Task.order(due_at: :asc)
-    else
-      @tasks = Task.order(created_at: :desc)
-    end
+    @tasks = if params[:sort_by] == 'due_at'
+               Task.order(due_at: :asc)
+             else
+               Task.order(created_at: :desc)
+             end
   end
 
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,11 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.order(created_at: :desc)
+    if params[:sort_by] == 'due_at'
+      @tasks = Task.order(due_at: :asc)
+    else
+      @tasks = Task.order(created_at: :desc)
+    end
   end
 
   def new

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -16,3 +16,5 @@ table
       td = link_to t('view.task.link_text.edit'), edit_task_path(task.id)
       td = link_to t('view.task.link_text.delete'), task, method: :delete, data: {confirm: t('view.task.message.delete_confirm')}
 div = link_to t('view.task.link_text.new'), new_task_path
+div = link_to '期限が近い順でソートする', tasks_path(sort_by: 'due_at')
+div = link_to '作成日時が近い順でソートする', tasks_path

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -16,5 +16,5 @@ table
       td = link_to t('view.task.link_text.edit'), edit_task_path(task.id)
       td = link_to t('view.task.link_text.delete'), task, method: :delete, data: {confirm: t('view.task.message.delete_confirm')}
 div = link_to t('view.task.link_text.new'), new_task_path
-div = link_to '期限が近い順でソートする', tasks_path(sort_by: 'due_at')
-div = link_to '作成日時が近い順でソートする', tasks_path
+div = link_to t('view.task.link_text.sort_by_due_at'), tasks_path(sort_by: 'due_at')
+div = link_to t('view.task.link_text.sort_by_created_at'), tasks_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,8 @@ en:
         delete: "Delte"
         add: "Add a new task"
         back: "Back"
+        sort_by_due_at: "Sort by due at"
+        sort_by_created_at: "Sort by created at"
   activerecord:
     errors:
       messages:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -23,6 +23,8 @@ ja:
         edit: "編集"
         delete: "削除"
         back: "戻る"
+        sort_by_due_at: "終了期限が近い順でソートする"
+        sort_by_created_at: "作成日時が近い順でソートする"
   activerecord:
     errors:
       messages:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,7 +24,7 @@ ja:
         delete: "削除"
         back: "戻る"
         sort_by_due_at: "終了期限が近い順でソートする"
-        sort_by_created_at: "作成日時が近い順でソートする"
+        sort_by_created_at: "作成日時が新しい順でソートする"
   activerecord:
     errors:
       messages:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,7 +5,7 @@ ja:
       label:
         title: "タスク名"
         description: "タスクの説明"
-        due_at: "期限"
+        due_at: "終了期限"
         status: "ステータス"
         priority: "優先度"
       button:

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,5 +5,14 @@ FactoryBot.define do
     due_at Date.parse('2020-01-01')
     status '1'
     priority '1'
+
+    factory :new_task do
+      created_at Date.parse('2020-01-01')
+    end
+
+    factory :old_task do
+      created_at Date.parse('2000-01-01')
+    end
   end
+
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -83,4 +83,17 @@ describe 'タスク' do
       expect(page.all('tr')[2]).to have_link('編集', href: edit_task_path(new_task.id))
     end
   end
+
+  context 'タスクを作成日時が新しい順でソートする' do
+    it '作成日時順でソートするリンクがある' do
+      visit tasks_path
+      expect(page).to have_content I18n.t('view.task.link_text.sort_by_created_at')
+    end
+
+    it 'リンクにパラメータがついていない' do
+      visit tasks_path
+      click_link I18n.t('view.task.link_text.sort_by_created_at')
+      expect(current_path).to eq ('/tasks')
+    end
+  end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -17,7 +17,7 @@ describe 'タスク' do
       expect(page).to have_content title
     end
 
-    it '作成完了のフラッシュメッセージが表示される' do
+    it '作成完了のフラッシュメッセージを表示する' do
       visit new_task_path
       fill_in I18n.t('view.task.label.title'), with: title
       fill_in I18n.t('view.task.label.description'), with: 'テスト用タスクです'
@@ -39,7 +39,7 @@ describe 'タスク' do
       expect(page).to have_content title_edited
     end
 
-    it '更新完了のフラッシュメッセージが表示される' do
+    it '更新完了のフラッシュメッセージを表示する' do
       visit edit_task_path(task.id)
       fill_in I18n.t('view.task.label.title'), with: '変更タスク'
       click_button I18n.t('view.task.button.submit')
@@ -56,20 +56,31 @@ describe 'タスク' do
       expect(page).not_to have_content title
     end
 
-    it '削除完了のフラッシュメッセージが表示される' do
+    it '削除完了のフラッシュメッセージを表示する' do
       visit tasks_path
       click_link I18n.t('view.task.link_text.delete')
       expect(page).to have_content I18n.t('view.task.message.deleted')
     end
   end
 
-  context 'タスクが作成日時の降順で表示される' do
+  context 'タスクを作成日時の降順で表示する' do
     let! (:new_task) { create(:task, created_at: '2020-01-01') }
     let! (:old_task) { create(:task, created_at: '2000-01-01') }
     it 'タスクを降順でソートする' do
       visit tasks_path
       expect(page.all('tr')[1]).to have_link('編集', href: edit_task_path(new_task.id))
       expect(page.all('tr')[2]).to have_link('編集', href: edit_task_path(old_task.id))
+    end
+  end
+
+  context 'タスクを終了期限の近い順で表示する' do
+    let! (:new_task) { create(:task, due_at: '2020-01-01') }
+    let! (:old_task) { create(:task, due_at: '2000-01-01') }
+    it '終了期限順でソートする' do
+      visit tasks_path
+      click_link I18n.t('view.task.link_text.sort_by_due_at')
+      expect(page.all('tr')[1]).to have_link('編集', href: edit_task_path(old_task.id))
+      expect(page.all('tr')[2]).to have_link('編集', href: edit_task_path(new_task.id))
     end
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -64,8 +64,8 @@ describe 'タスク' do
   end
 
   context 'タスクを作成日時の降順で表示する' do
-    let! (:new_task) { create(:task, created_at: '2020-01-01') }
-    let! (:old_task) { create(:task, created_at: '2000-01-01') }
+    let! (:new_task) { create(:new_task) }
+    let! (:old_task) { create(:old_task) }
     it 'タスクを降順でソートする' do
       visit tasks_path
       expect(page.all('tr')[1]).to have_link('編集', href: edit_task_path(new_task.id))
@@ -74,8 +74,8 @@ describe 'タスク' do
   end
 
   context 'タスクを終了期限の近い順で表示する' do
-    let! (:new_task) { create(:task, due_at: '2020-01-01') }
-    let! (:old_task) { create(:task, due_at: '2000-01-01') }
+    let! (:new_task) { create(:new_task, due_at: '2020-01-01') }
+    let! (:old_task) { create(:old_task, due_at: '2000-01-01') }
     it '終了期限順でソートする' do
       visit tasks_path
       click_link I18n.t('view.task.link_text.sort_by_due_at')


### PR DESCRIPTION
## 何をやったか
[ステップ14](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9714-%E7%B5%82%E4%BA%86%E6%9C%9F%E9%99%90%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86)の要件である、「タスクを終了期限が近い順でソートする」機能を実装しました。

なお、カリキュラムにある
> タスクに対して、終了期限を登録できるようにしてみましょう

に関しては、https://github.com/tsumichan/todo-app/pull/9 ですでに対応済です。

## こんな感じです

 👇 **トップページにアクセスしたとき**
![image](https://user-images.githubusercontent.com/14156156/42615353-ccf7ea2e-85e4-11e8-8cb2-622eb05c2ed9.png)

 👇 **「終了期限が近い順でソートする」リンクを押したとき**
![image](https://user-images.githubusercontent.com/14156156/42615366-e016a316-85e4-11e8-817a-ffec43a238b4.png)

 👇 **「作成日時が新しい順でソートする」リンクを押したとき**
![image](https://user-images.githubusercontent.com/14156156/42615380-f8a9c52a-85e4-11e8-8ee0-c33444d6de08.png)

※わかりやすいよう、一時的に作成日時（`created_at`）を表示しています


## レビューポイント

- 余計なインデント、スペースがないか
- 終了期限が近い順でソートする処理が正しく書けているかどうか
- テストが正しく書けているかどうか
- 無駄な記述の仕方をしていないか


## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:
