### PR TITLE
タイトルとステータスで検索できるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'slim-rails'
 gem 'http_accept_language'
+gem 'enum_help'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,8 @@ GEM
     crass (1.0.4)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.7.1)
     execjs (2.7.0)
     factory_bot (4.10.0)
@@ -248,6 +250,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   database_cleaner
+  enum_help
   factory_bot_rails
   faker
   http_accept_language

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,12 +2,9 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    word = params[:search]
-    status = params[:status]
-    sort = params[:sort]
     @statuses = Task.statuses.map { |k, v| [t("enums.task.status.#{k}"), v]}
     @sorts = Task.sorts.map { |k, v| [t("enums.task.sort.#{k}"), v]}
-    @tasks = Task.search_by_title(word).search_by_status(status).sort_by_due_at(sort)
+    @tasks = Task.search_by_title(params[:search]).search_by_status(params[:status]).sort_by_due_at(params[:sort])
   end
   def new
     @task = Task.new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,8 +5,8 @@ class TasksController < ApplicationController
     @tasks = if params[:sort_by] == 'due_at'
                Task.order(due_at: :asc)
              elsif params[:search].present?
-               search = params[:search]
-               Task.where('title LIKE ?', "%#{search}%")
+               word = params[:search]
+               Task.search(word)
              else
                Task.order(created_at: :desc)
              end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,6 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
+    @statuses = Task.statuses
     @tasks = if params[:sort_by] == 'due_at'
                Task.order(due_at: :asc)
              elsif params[:search].present?

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,7 +3,7 @@ class TasksController < ApplicationController
 
   def index
     @statuses = Task.statuses.map { |k, v| [t("enums.task.status.#{k}"), v]}
-    @sorts = Task.sorts.map { |k, v| [t("enums.task.sort.#{k}"), v]}
+    @sorts = [t("view.task.sort.created_at"), 0], [t("view.task.sort.due_at"), 1]
     @tasks = Task.search_by_title(params[:search]).search_by_status(params[:status]).sort_by_due_at(params[:sort])
   end
   def new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,6 +7,9 @@ class TasksController < ApplicationController
              elsif params[:search].present?
                word = params[:search]
                Task.search(word)
+             elsif params[:status].present?
+               status = params[:status]
+               Task.search_status(status)
              else
                Task.order(created_at: :desc)
              end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,7 +7,7 @@ class TasksController < ApplicationController
     sort = params[:sort]
     @statuses = Task.statuses.map { |k, v| [t("enums.task.status.#{k}"), v]}
     @sorts = Task.sorts.map { |k, v| [t("enums.task.sort.#{k}"), v]}
-    @tasks = Task.search(word).search_status(status).sort_by_due_at(sort)
+    @tasks = Task.search_by_title(word).search_by_status(status).sort_by_due_at(sort)
   end
   def new
     @task = Task.new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @statuses = Task.statuses
+    @statuses = Task.statuses.map { |k, v| [t("enums.task.status.#{k}"), v]}
     @tasks = if params[:sort_by] == 'due_at'
                Task.order(due_at: :asc)
              elsif params[:search].present? || params[:status].present?

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,12 +5,10 @@ class TasksController < ApplicationController
     @statuses = Task.statuses
     @tasks = if params[:sort_by] == 'due_at'
                Task.order(due_at: :asc)
-             elsif params[:search].present?
+             elsif params[:search].present? || params[:status].present?
                word = params[:search]
-               Task.search(word)
-             elsif params[:status].present?
                status = params[:status]
-               Task.search_status(status)
+               Task.search(word).search_status(status)
              else
                Task.order(created_at: :desc)
              end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,6 +4,9 @@ class TasksController < ApplicationController
   def index
     @tasks = if params[:sort_by] == 'due_at'
                Task.order(due_at: :asc)
+             elsif params[:search].present?
+               search = params[:search]
+               Task.where('title LIKE ?', "%#{search}%")
              else
                Task.order(created_at: :desc)
              end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,18 +2,13 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
+    word = params[:search]
+    status = params[:status]
+    sort = params[:sort]
     @statuses = Task.statuses.map { |k, v| [t("enums.task.status.#{k}"), v]}
-    @tasks = if params[:sort_by] == 'due_at'
-               Task.order(due_at: :asc)
-             elsif params[:search].present? || params[:status].present?
-               word = params[:search]
-               status = params[:status]
-               Task.search(word).search_status(status)
-             else
-               Task.order(created_at: :desc)
-             end
+    @sorts = Task.sorts.map { |k, v| [t("enums.task.sort.#{k}"), v]}
+    @tasks = Task.search(word).search_status(status).sort_by_due_at(sort)
   end
-
   def new
     @task = Task.new
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,11 +3,6 @@ class Task < ApplicationRecord
   validates :description, length: { maximum: 255 }
   enum status: { waiting: 0, working:1, completed: 2 }
 
-  def self.search(key)
-    self.where('title LIKE ?', "%#{key}%")
-  end
-
-  def self.search_status(key)
-    self.where(status: key)
-  end
+  scope :search, ->(key) { where('title LIKE ?', "%#{key}%") }
+  scope :search_status, ->(key) { where(status: key) if key.present? }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,7 @@
 class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, length: { maximum: 255 }
-  enum status: { Todo: 0, Doing: 1, Done: 2 }
+  enum status: { todo: 0, doing: 1, done: 2 }
 
   scope :search, ->(word) { where('title LIKE ?', "%#{word}%") if word.present? }
   scope :search_status, ->(status) { where(status: status) if status.present? }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,7 +2,10 @@ class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, length: { maximum: 255 }
   enum status: { todo: 0, doing: 1, done: 2 }
+  enum sort: { created_at: 0, due_at: 1 }
 
   scope :search, ->(word) { where('title LIKE ?', "%#{word}%") if word.present? }
   scope :search_status, ->(status) { where(status: status) if status.present? }
+  scope :sort_by_due_at, ->(sort) {
+    sort == '1' ? order(due_at: :asc) : order(created_at: :desc) }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,7 +2,6 @@ class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, length: { maximum: 255 }
   enum status: { todo: 0, doing: 1, done: 2 }
-  enum sort: { created_at: 0, due_at: 1 }
 
   scope :search_by_title, ->(word) { where('title LIKE ?', "%#{word}%") if word.present? }
   scope :search_by_status, ->(status) { where(status: status) if status.present? }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,4 +5,8 @@ class Task < ApplicationRecord
   def self.search(key)
     self.where('title LIKE ?', "%#{key}%")
   end
+
+  def self.search_status(key)
+    self.where(status: key)
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,8 +4,8 @@ class Task < ApplicationRecord
   enum status: { todo: 0, doing: 1, done: 2 }
   enum sort: { created_at: 0, due_at: 1 }
 
-  scope :search, ->(word) { where('title LIKE ?', "%#{word}%") if word.present? }
-  scope :search_status, ->(status) { where(status: status) if status.present? }
+  scope :search_by_title, ->(word) { where('title LIKE ?', "%#{word}%") if word.present? }
+  scope :search_by_status, ->(status) { where(status: status) if status.present? }
   scope :sort_by_due_at, ->(sort) {
     sort == '1' ? order(due_at: :asc) : order(created_at: :desc) }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,7 @@
 class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, length: { maximum: 255 }
+  enum status: { waiting: 0, working:1, completed: 2 }
 
   def self.search(key)
     self.where('title LIKE ?', "%#{key}%")

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,6 @@ class Task < ApplicationRecord
   validates :description, length: { maximum: 255 }
   enum status: { Todo: 0, Doing: 1, Done: 2 }
 
-  scope :search, ->(key) { where('title LIKE ?', "%#{key}%") }
-  scope :search_status, ->(key) { where(status: key) if key.present? }
+  scope :search, ->(word) { where('title LIKE ?', "%#{word}%") }
+  scope :search_status, ->(status) { where(status: status) if status.present? }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,7 @@
 class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, length: { maximum: 255 }
-  enum status: { Todo: 0, Doing:1, Done: 2 }
+  enum status: { Todo: 0, Doing: 1, Done: 2 }
 
   scope :search, ->(key) { where('title LIKE ?', "%#{key}%") }
   scope :search_status, ->(key) { where(status: key) if key.present? }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,8 @@
 class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, length: { maximum: 255 }
+
+  def self.search(key)
+    self.where('title LIKE ?', "%#{key}%")
+  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,5 +6,12 @@ class Task < ApplicationRecord
   scope :search_by_title, ->(word) { where('title LIKE ?', "%#{word}%") if word.present? }
   scope :search_by_status, ->(status) { where(status: status) if status.present? }
   scope :sort_by_due_at, ->(sort) {
-    sort == '1' ? order(due_at: :asc) : order(created_at: :desc) }
+    option = case sort.to_i
+         when 1
+           { due_at: :asc }
+         else
+           { created_at: :desc }
+         end
+    order(option)
+  }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,6 @@ class Task < ApplicationRecord
   validates :description, length: { maximum: 255 }
   enum status: { Todo: 0, Doing: 1, Done: 2 }
 
-  scope :search, ->(word) { where('title LIKE ?', "%#{word}%") }
+  scope :search, ->(word) { where('title LIKE ?', "%#{word}%") if word.present? }
   scope :search_status, ->(status) { where(status: status) if status.present? }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,7 +1,7 @@
 class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, length: { maximum: 255 }
-  enum status: { waiting: 0, working:1, completed: 2 }
+  enum status: { Todo: 0, Doing:1, Done: 2 }
 
   scope :search, ->(key) { where('title LIKE ?', "%#{key}%") }
   scope :search_status, ->(key) { where(status: key) if key.present? }

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -26,7 +26,7 @@ table
 div = link_to t('view.task.link_text.new'), new_task_path
 div = link_to t('view.task.link_text.sort_by_due_at'), tasks_path(sort_by: 'due_at')
 div = link_to t('view.task.link_text.sort_by_created_at'), tasks_path
-div = link_to '「未着手」で検索', tasks_path(status: 0)
-div = link_to '「着手」で検索', tasks_path(status: 1)
-div = link_to '「完了」で検索', tasks_path(status: 2)
+div = link_to t('view.task.link_text.search_by_waiting_task'), tasks_path(status: 0)
+div = link_to t('view.task.link_text.search_by_working_task'), tasks_path(status: 1)
+div = link_to t('view.task.link_text.search_by_completed_task'), tasks_path(status: 2)
 div = link_to '検索条件をクリア', tasks_path

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -22,7 +22,7 @@ table
         td = link_to t('view.task.link_text.edit'), edit_task_path(task.id)
         td = link_to t('view.task.link_text.delete'), task, method: :delete, data: {confirm: t('view.task.message.delete_confirm')}
   - else
-    div 該当するタスクはありません
+    div = t('view.task.message.no_match_task')
 div = link_to t('view.task.link_text.new'), new_task_path
 div = link_to t('view.task.link_text.sort_by_due_at'), tasks_path(sort_by: 'due_at')
 div = link_to t('view.task.link_text.sort_by_created_at'), tasks_path

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -17,7 +17,7 @@ table
       tr
         td = link_to task.title, task
         td = task.due_at
-        td = task.status
+        td = task.status_i18n
         td = task.priority
         td = link_to t('view.task.link_text.edit'), edit_task_path(task.id)
         td = link_to t('view.task.link_text.delete'), task, method: :delete, data: {confirm: t('view.task.message.delete_confirm')}

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -27,4 +27,3 @@ table
 div = link_to t('view.task.link_text.new'), new_task_path
 div = link_to t('view.task.link_text.sort_by_due_at'), tasks_path(sort_by: 'due_at')
 div = link_to t('view.task.link_text.sort_by_created_at'), tasks_path
-div = link_to '検索条件をクリア', tasks_path

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -4,6 +4,7 @@
 = form_tag tasks_path, :method => 'get' do
   div
     = text_field_tag :search, params[:search]
+    = select_tag :status, options_for_select(@statuses), include_blank: true
     = submit_tag t('view.task.button.search')
 
 table
@@ -26,7 +27,4 @@ table
 div = link_to t('view.task.link_text.new'), new_task_path
 div = link_to t('view.task.link_text.sort_by_due_at'), tasks_path(sort_by: 'due_at')
 div = link_to t('view.task.link_text.sort_by_created_at'), tasks_path
-div = link_to t('view.task.link_text.search_by_waiting_task'), tasks_path(status: 0)
-div = link_to t('view.task.link_text.search_by_working_task'), tasks_path(status: 1)
-div = link_to t('view.task.link_text.search_by_completed_task'), tasks_path(status: 2)
 div = link_to '検索条件をクリア', tasks_path

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -5,6 +5,7 @@
   div
     = text_field_tag :search, params[:search]
     = select_tag :status, options_for_select(@statuses), include_blank: true
+    = select_tag :sort, options_for_select(@sorts)
     = submit_tag t('view.task.button.search')
 
 table
@@ -24,8 +25,7 @@ table
             td = task.priority
             td = link_to t('view.task.link_text.edit'), edit_task_path(task.id)
             td = link_to t('view.task.link_text.delete'), task, method: :delete, data: {confirm: t('view.task.message.delete_confirm')}
+            td = task.created_at
     - else
       div = t('view.task.message.no_match_task')
 div = link_to t('view.task.link_text.new'), new_task_path
-div = link_to t('view.task.link_text.sort_by_due_at'), tasks_path(sort_by: 'due_at')
-div = link_to t('view.task.link_text.sort_by_created_at'), tasks_path

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -26,3 +26,7 @@ table
 div = link_to t('view.task.link_text.new'), new_task_path
 div = link_to t('view.task.link_text.sort_by_due_at'), tasks_path(sort_by: 'due_at')
 div = link_to t('view.task.link_text.sort_by_created_at'), tasks_path
+div = link_to '「未着手」で検索', tasks_path(status: 0)
+div = link_to '「着手」で検索', tasks_path(status: 1)
+div = link_to '「完了」で検索', tasks_path(status: 2)
+div = link_to '検索条件をクリア', tasks_path

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,20 +1,28 @@
 - flash.each do |key, value|
   = content_tag(:div, value, class: key)
 
+= form_tag tasks_path, :method => 'get' do
+  div
+    = text_field_tag :search, params[:search]
+    = submit_tag t('view.task.button.search')
+
 table
   tr
     th = t('view.task.label.title')
     th = t('view.task.label.due_at')
     th = t('view.task.label.status')
     th = t('view.task.label.priority')
-  - @tasks.each do |task|
-    tr
-      td = link_to task.title, task
-      td = task.due_at
-      td = task.status
-      td = task.priority
-      td = link_to t('view.task.link_text.edit'), edit_task_path(task.id)
-      td = link_to t('view.task.link_text.delete'), task, method: :delete, data: {confirm: t('view.task.message.delete_confirm')}
+  - if @tasks.exists?
+    - @tasks.each do |task|
+      tr
+        td = link_to task.title, task
+        td = task.due_at
+        td = task.status
+        td = task.priority
+        td = link_to t('view.task.link_text.edit'), edit_task_path(task.id)
+        td = link_to t('view.task.link_text.delete'), task, method: :delete, data: {confirm: t('view.task.message.delete_confirm')}
+  - else
+    div 該当するタスクはありません
 div = link_to t('view.task.link_text.new'), new_task_path
 div = link_to t('view.task.link_text.sort_by_due_at'), tasks_path(sort_by: 'due_at')
 div = link_to t('view.task.link_text.sort_by_created_at'), tasks_path

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -25,7 +25,6 @@ table
             td = task.priority
             td = link_to t('view.task.link_text.edit'), edit_task_path(task.id)
             td = link_to t('view.task.link_text.delete'), task, method: :delete, data: {confirm: t('view.task.message.delete_confirm')}
-            td = task.created_at
     - else
       div = t('view.task.message.no_match_task')
 div = link_to t('view.task.link_text.new'), new_task_path

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -8,22 +8,24 @@
     = submit_tag t('view.task.button.search')
 
 table
-  tr
-    th = t('view.task.label.title')
-    th = t('view.task.label.due_at')
-    th = t('view.task.label.status')
-    th = t('view.task.label.priority')
-  - if @tasks.exists?
-    - @tasks.each do |task|
-      tr
-        td = link_to task.title, task
-        td = task.due_at
-        td = task.status_i18n
-        td = task.priority
-        td = link_to t('view.task.link_text.edit'), edit_task_path(task.id)
-        td = link_to t('view.task.link_text.delete'), task, method: :delete, data: {confirm: t('view.task.message.delete_confirm')}
-  - else
-    div = t('view.task.message.no_match_task')
+  thead
+    tr
+      th = t('view.task.label.title')
+      th = t('view.task.label.due_at')
+      th = t('view.task.label.status')
+      th = t('view.task.label.priority')
+    - if @tasks.exists?
+      tbody
+        - @tasks.each do |task|
+          tr
+            td = link_to task.title, task
+            td = task.due_at
+            td = task.status_i18n
+            td = task.priority
+            td = link_to t('view.task.link_text.edit'), edit_task_path(task.id)
+            td = link_to t('view.task.link_text.delete'), task, method: :delete, data: {confirm: t('view.task.message.delete_confirm')}
+    - else
+      div = t('view.task.message.no_match_task')
 div = link_to t('view.task.link_text.new'), new_task_path
 div = link_to t('view.task.link_text.sort_by_due_at'), tasks_path(sort_by: 'due_at')
 div = link_to t('view.task.link_text.sort_by_created_at'), tasks_path

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,9 @@ en:
         back: "Back"
         sort_by_due_at: "Sort by due at"
         sort_by_created_at: "Sort by created at"
+        search_by_waiting_task: "Search by waiting task"
+        search_by_working_task: "Search by working task"
+        search_by_completed_task: "Search by completed task"
   activerecord:
     errors:
       messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,9 +34,6 @@ en:
         back: "Back"
         sort_by_due_at: "Sort by due at"
         sort_by_created_at: "Sort by created at"
-        search_by_waiting_task: "Search by waiting task"
-        search_by_working_task: "Search by working task"
-        search_by_completed_task: "Search by completed task"
   activerecord:
     errors:
       messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,9 +3,9 @@ en:
   enums:
     task:
       status:
-        Todo: "Todo"
-        Doing: "Doing"
-        Done: "Done"
+        todo: "Todo"
+        doing: "Doing"
+        done: "Done"
   view:
     task:
       label:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,9 @@ en:
         todo: "Todo"
         doing: "Doing"
         done: "Done"
+      sort:
+        due_at: "Sort by due at"
+        created_at: "Sort by created at"
   view:
     task:
       label:
@@ -32,8 +35,6 @@ en:
         delete: "Delte"
         add: "Add a new task"
         back: "Back"
-        sort_by_due_at: "Sort by due at"
-        sort_by_created_at: "Sort by created at"
   activerecord:
     errors:
       messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
         updated: "Updated a task"
         deleted: "Deleted a task"
         delete_confirm: "Are you sure you want to delte this task?"
+        no_match_task: "There is no matching task"
       link_text:
         new: "New"
         edit: "Edit"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
         priority: "Priority"
       button:
         submit: "Submit"
+        search: "Search"
       title:
         new: "Create new task"
         edit: "Edit the task"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,9 +3,9 @@ en:
   enums:
     task:
       status:
-        waiting: "Waiting"
-        working: "Working"
-        completed: "Completed"
+        Todo: "Todo"
+        Doing: "Doing"
+        Done: "Done"
   view:
     task:
       label:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,11 @@
 ---
 en:
+  enums:
+    task:
+      status:
+        waiting: "Waiting"
+        working: "Working"
+        completed: "Completed"
   view:
     task:
       label:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,9 +3,9 @@ ja:
   enums:
     task:
       status:
-        Todo: "未着手"
-        Doing: "着手中"
-        Done: "完了"
+        todo: "未着手"
+        doing: "着手中"
+        done: "完了"
   view:
     task:
       label:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,7 +4,7 @@ ja:
     task:
       status:
         Todo: "未着手"
-        Doing: "着手"
+        Doing: "着手中"
         Done: "完了"
   view:
     task:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -26,6 +26,9 @@ ja:
         back: "戻る"
         sort_by_due_at: "終了期限が近い順でソートする"
         sort_by_created_at: "作成日時が新しい順でソートする"
+        search_by_waiting_task: "「未着手」で検索"
+        search_by_working_task: "「着手」で検索"
+        search_by_completed_task: "「完了」で検索"
   activerecord:
     errors:
       messages:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,9 +6,6 @@ ja:
         todo: "未着手"
         doing: "着手中"
         done: "完了"
-      sort:
-        due_at: "終了期限が近い順でソートする"
-        created_at: "作成日時が新しい順でソートする"
   view:
     task:
       label:
@@ -34,6 +31,9 @@ ja:
         edit: "編集"
         delete: "削除"
         back: "戻る"
+      sort:
+        due_at: "終了期限が近い順でソートする"
+        created_at: "作成日時が新しい順でソートする"
   activerecord:
     errors:
       messages:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,11 @@
 ---
 ja:
+  enums:
+    task:
+      status:
+        waiting: "未着手"
+        working: "着手"
+        completed: "完了"
   view:
     task:
       label:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -3,9 +3,9 @@ ja:
   enums:
     task:
       status:
-        waiting: "未着手"
-        working: "着手"
-        completed: "完了"
+        Todo: "未着手"
+        Doing: "着手"
+        Done: "完了"
   view:
     task:
       label:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -33,9 +33,6 @@ ja:
         back: "戻る"
         sort_by_due_at: "終了期限が近い順でソートする"
         sort_by_created_at: "作成日時が新しい順でソートする"
-        search_by_waiting_task: "「未着手」で検索"
-        search_by_working_task: "「着手」で検索"
-        search_by_completed_task: "「完了」で検索"
   activerecord:
     errors:
       messages:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,7 @@ ja:
         priority: "優先度"
       button:
         submit: "登録"
+        search: "検索"
       title:
         new: "タスクを追加する"
         edit: "タスクを編集する"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,6 +19,7 @@ ja:
         updated: "タスクを更新しました"
         deleted: "タスクを削除しました"
         delete_confirm: "本当に削除しますか？"
+        no_match_task: "該当するタスクはありません"
       link_text:
         new: "タスクを追加"
         edit: "編集"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,9 @@ ja:
         todo: "未着手"
         doing: "着手中"
         done: "完了"
+      sort:
+        due_at: "終了期限が近い順でソートする"
+        created_at: "作成日時が新しい順でソートする"
   view:
     task:
       label:
@@ -31,8 +34,6 @@ ja:
         edit: "編集"
         delete: "削除"
         back: "戻る"
-        sort_by_due_at: "終了期限が近い順でソートする"
-        sort_by_created_at: "作成日時が新しい順でソートする"
   activerecord:
     errors:
       messages:

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -17,6 +17,10 @@ FactoryBot.define do
     factory :working_task do
       status 'working'
     end
+
+    factory :sample_title_task do
+      title 'サンプル用タスクです'
+    end
   end
 
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -13,6 +13,10 @@ FactoryBot.define do
     factory :old_task do
       created_at Date.parse('2000-01-01')
     end
+
+    factory :working_task do
+      status 'working'
+    end
   end
 
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -13,14 +13,5 @@ FactoryBot.define do
     factory :old_task do
       created_at Date.parse('2000-01-01')
     end
-
-    factory :doing_task do
-      status 'doing'
-    end
-
-    factory :sample_title_task do
-      title 'サンプル用タスクです'
-    end
   end
-
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     title 'テスト用タスク'
     description 'テスト用タスクです'
     due_at Date.parse('2020-01-01')
-    status 'Todo'
+    status 'todo'
     priority '1'
 
     factory :new_task do
@@ -15,7 +15,7 @@ FactoryBot.define do
     end
 
     factory :doing_task do
-      status 'Doing'
+      status 'doing'
     end
 
     factory :sample_title_task do

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     title 'テスト用タスク'
     description 'テスト用タスクです'
     due_at Date.parse('2020-01-01')
-    status '1'
+    status 'waiting'
     priority '1'
 
     factory :new_task do

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     title 'テスト用タスク'
     description 'テスト用タスクです'
     due_at Date.parse('2020-01-01')
-    status 'waiting'
+    status 'Todo'
     priority '1'
 
     factory :new_task do
@@ -14,8 +14,8 @@ FactoryBot.define do
       created_at Date.parse('2000-01-01')
     end
 
-    factory :working_task do
-      status 'working'
+    factory :doing_task do
+      status 'Doing'
     end
 
     factory :sample_title_task do

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 describe 'タスク' do
   let(:title) { 'テスト用タスク' }
   let(:title_edited) { '変更用タスク' }
+  let(:test_title) { 'テスト' }
+
 
   context '新規のタスクを作成する' do
     it '作成する' do
@@ -97,13 +99,14 @@ describe 'タスク' do
     end
   end
 
-  context 'タスクをタイトルで検索する' do
+  context 'タスクを検索する' do
     let!(:task) { create(:task) }
+    let!(:working_task) { create_list(:working_task, 3)}
     it '入力された文字列で検索をする' do
       visit tasks_path
-      fill_in :search, with: 'テスト'
+      fill_in :search, with: test_title
       click_button I18n.t('view.task.button.search')
-      expect(page).to have_content 'テスト'
+      expect(page).to have_content test_title
     end
 
     it 'マッチするものがない場合、マッチするものがなかったことを知らせる' do
@@ -112,17 +115,21 @@ describe 'タスク' do
       click_button I18n.t('view.task.button.search')
       expect(page).to have_content I18n.t('view.task.message.no_match_task')
     end
-  end
 
-  context 'タスクをステータスで検索する' do
-    let!(:working_task) { create_list(:working_task, 3)}
-    it 'ステータスで検索' do
+    it 'ステータスで検索する' do
       visit tasks_path
       select 'working', from: 'status'
       click_button I18n.t('view.task.button.search')
-      binding.pry
-      searched_task = Task.search('タスク').search_status('working')
-      expect(page.all('tr').count).to eq searched_task.count + 1
+      searched_task = Task.search_status('working')
+      expect(page.all('tbody tr').count).to eq searched_task.count
+    end
+
+    it 'タイトルとステータスで検索する' do
+      visit tasks_path
+      fill_in 'search', with: test_title
+      select 'working', from: 'status'
+      click_button I18n.t('view.task.button.search')
+      searched_task = Task.search(test_title).search_status('working')
       expect(page.all('tbody tr').count).to eq searched_task.count
     end
   end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -68,8 +68,8 @@ describe 'タスク' do
     let! (:old_task) { create(:old_task) }
     it 'タスクを降順でソートする' do
       visit tasks_path
-      expect(page.all('tr')[1]).to have_link('編集', href: edit_task_path(new_task.id))
-      expect(page.all('tr')[2]).to have_link('編集', href: edit_task_path(old_task.id))
+      expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(new_task.id))
+      expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(old_task.id))
     end
   end
 
@@ -79,8 +79,8 @@ describe 'タスク' do
     it '終了期限順でソートする' do
       visit tasks_path
       click_link I18n.t('view.task.link_text.sort_by_due_at')
-      expect(page.all('tr')[1]).to have_link('編集', href: edit_task_path(old_task.id))
-      expect(page.all('tr')[2]).to have_link('編集', href: edit_task_path(new_task.id))
+      expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(old_task.id))
+      expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(new_task.id))
     end
   end
 
@@ -123,6 +123,7 @@ describe 'タスク' do
       binding.pry
       searched_task = Task.search('タスク').search_status('working')
       expect(page.all('tr').count).to eq searched_task.count + 1
+      expect(page.all('tbody tr').count).to eq searched_task.count
     end
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -113,4 +113,16 @@ describe 'タスク' do
       expect(page).to have_content I18n.t('view.task.message.no_match_task')
     end
   end
+
+  context 'タスクをステータスで検索する' do
+    let!(:working_task) { create_list(:working_task, 3)}
+    it 'ステータスで検索' do
+      visit tasks_path
+      select 'working', from: 'status'
+      click_button I18n.t('view.task.button.search')
+      binding.pry
+      searched_task = Task.search('タスク').search_status('working')
+      expect(page.all('tr').count).to eq searched_task.count + 1
+    end
+  end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -10,7 +10,7 @@ describe 'タスク' do
       fill_in I18n.t('view.task.label.title'), with: title
       fill_in I18n.t('view.task.label.description'), with: 'テスト用タスクです'
       fill_in I18n.t('view.task.label.due_at'), with: '2020-01-01 00:00:00'
-      fill_in I18n.t('view.task.label.status'), with: '1'
+      fill_in I18n.t('view.task.label.status'), with: 'waiting'
       fill_in I18n.t('view.task.label.priority'), with: '1'
       click_button I18n.t('view.task.button.submit')
       expect(Task.exists?(title: title)).to be true
@@ -22,7 +22,7 @@ describe 'タスク' do
       fill_in I18n.t('view.task.label.title'), with: title
       fill_in I18n.t('view.task.label.description'), with: 'テスト用タスクです'
       fill_in I18n.t('view.task.label.due_at'), with: '2020-01-01 00:00:00'
-      fill_in I18n.t('view.task.label.status'), with: '1'
+      fill_in I18n.t('view.task.label.status'), with: 'waiting'
       fill_in I18n.t('view.task.label.priority'), with: '1'
       click_button I18n.t('view.task.button.submit')
       expect(page).to have_content I18n.t('view.task.message.created')

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -79,7 +79,7 @@ describe 'タスク' do
     let! (:old_task) { create(:old_task, due_at: '2000-01-01') }
     it '終了期限が近い順でソートする' do
       visit tasks_path
-      select I18n.t('enums.task.sort.due_at'), from: 'sort'
+      select I18n.t('view.task.sort.due_at'), from: 'sort'
       click_button I18n.t('view.task.button.search')
       expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(old_task.id))
       expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(new_task.id))
@@ -87,7 +87,7 @@ describe 'タスク' do
 
     it '作成日時が新しい順でソートする' do
       visit tasks_path
-      select I18n.t('enums.task.sort.created_at'), from: 'sort'
+      select I18n.t('view.task.sort.created_at'), from: 'sort'
       click_button I18n.t('view.task.button.search')
       expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(new_task.id))
       expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(old_task.id))

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -5,7 +5,6 @@ describe 'タスク' do
   let(:title_edited) { '変更用タスク' }
   let(:test_title) { 'テスト' }
 
-
   context '新規のタスクを作成する' do
     it '作成する' do
       visit new_task_path

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -96,7 +96,6 @@ describe 'タスク' do
 
   context 'タスクを検索する' do
     let!(:task) { create(:task) }
-    let!(:doing_task) { create_list(:doing_task, 3)}
     it '入力された文字列で検索をする' do
       visit tasks_path
       fill_in :search, with: test_title
@@ -115,7 +114,7 @@ describe 'タスク' do
       visit tasks_path
       select I18n.t('enums.task.status.doing'), from: 'status'
       click_button I18n.t('view.task.button.search')
-      searched_task = Task.search_status('doing')
+      searched_task = Task.search_by_status('doing')
       expect(page.all('tbody tr').count).to eq searched_task.count
     end
 
@@ -124,7 +123,7 @@ describe 'タスク' do
       fill_in 'search', with: test_title
       select I18n.t('enums.task.status.doing'), from: 'status'
       click_button I18n.t('view.task.button.search')
-      searched_task = Task.search(test_title).search_status('doing')
+      searched_task = Task.search_by_title(test_title).search_by_status('doing')
       expect(page.all('tbody tr').count).to eq searched_task.count
     end
   end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -96,4 +96,21 @@ describe 'タスク' do
       expect(current_path).to eq ('/tasks')
     end
   end
+
+  context 'タスクをタイトルで検索する' do
+    let!(:task) { create(:task) }
+    it '入力された文字列で検索をする' do
+      visit tasks_path
+      fill_in :search, with: 'テスト'
+      click_button I18n.t('view.task.button.search')
+      expect(page).to have_content 'テスト'
+    end
+
+    it 'マッチするものがない場合、マッチするものがなかったことを知らせる' do
+      visit tasks_path
+      fill_in :search, with: 'サンプル'
+      click_button I18n.t('view.task.button.search')
+      expect(page).to have_content I18n.t('view.task.message.no_match_task')
+    end
+  end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -11,7 +11,7 @@ describe 'タスク' do
       fill_in I18n.t('view.task.label.title'), with: title
       fill_in I18n.t('view.task.label.description'), with: 'テスト用タスクです'
       fill_in I18n.t('view.task.label.due_at'), with: '2020-01-01 00:00:00'
-      fill_in I18n.t('view.task.label.status'), with: 'Todo'
+      fill_in I18n.t('view.task.label.status'), with: 'todo'
       fill_in I18n.t('view.task.label.priority'), with: '1'
       click_button I18n.t('view.task.button.submit')
       expect(Task.exists?(title: title)).to be true
@@ -23,7 +23,7 @@ describe 'タスク' do
       fill_in I18n.t('view.task.label.title'), with: title
       fill_in I18n.t('view.task.label.description'), with: 'テスト用タスクです'
       fill_in I18n.t('view.task.label.due_at'), with: '2020-01-01 00:00:00'
-      fill_in I18n.t('view.task.label.status'), with: 'Todo'
+      fill_in I18n.t('view.task.label.status'), with: 'todo'
       fill_in I18n.t('view.task.label.priority'), with: '1'
       click_button I18n.t('view.task.button.submit')
       expect(page).to have_content I18n.t('view.task.message.created')
@@ -117,18 +117,18 @@ describe 'タスク' do
 
     it 'ステータスで検索する' do
       visit tasks_path
-      select 'doing', from: 'status'
+      select I18n.t('enums.task.status.doing'), from: 'status'
       click_button I18n.t('view.task.button.search')
-      searched_task = Task.search_status('Doing')
+      searched_task = Task.search_status('doing')
       expect(page.all('tbody tr').count).to eq searched_task.count
     end
 
     it 'タイトルとステータスで検索する' do
       visit tasks_path
       fill_in 'search', with: test_title
-      select 'doing', from: 'status'
+      select I18n.t('enums.task.status.doing'), from: 'status'
       click_button I18n.t('view.task.button.search')
-      searched_task = Task.search(test_title).search_status('Doing')
+      searched_task = Task.search(test_title).search_status('doing')
       expect(page.all('tbody tr').count).to eq searched_task.count
     end
   end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -74,27 +74,23 @@ describe 'タスク' do
     end
   end
 
-  context 'タスクを終了期限の近い順で表示する' do
+  context 'タスクをソートする' do
     let! (:new_task) { create(:new_task, due_at: '2020-01-01') }
     let! (:old_task) { create(:old_task, due_at: '2000-01-01') }
-    it '終了期限順でソートする' do
+    it '終了期限が近い順でソートする' do
       visit tasks_path
-      click_link I18n.t('view.task.link_text.sort_by_due_at')
+      select I18n.t('enums.task.sort.due_at'), from: 'sort'
+      click_button I18n.t('view.task.button.search')
       expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(old_task.id))
       expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(new_task.id))
     end
-  end
 
-  context 'タスクを作成日時が新しい順でソートする' do
-    it '作成日時順でソートするリンクがある' do
+    it '作成日時が新しい順でソートする' do
       visit tasks_path
-      expect(page).to have_content I18n.t('view.task.link_text.sort_by_created_at')
-    end
-
-    it 'リンクにパラメータがついていない' do
-      visit tasks_path
-      click_link I18n.t('view.task.link_text.sort_by_created_at')
-      expect(current_path).to eq ('/tasks')
+      select I18n.t('enums.task.sort.created_at'), from: 'sort'
+      click_button I18n.t('view.task.button.search')
+      expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(new_task.id))
+      expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(old_task.id))
     end
   end
 

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -117,7 +117,7 @@ describe 'タスク' do
 
     it 'ステータスで検索する' do
       visit tasks_path
-      select 'Doing', from: 'status'
+      select 'doing', from: 'status'
       click_button I18n.t('view.task.button.search')
       searched_task = Task.search_status('Doing')
       expect(page.all('tbody tr').count).to eq searched_task.count
@@ -126,7 +126,7 @@ describe 'タスク' do
     it 'タイトルとステータスで検索する' do
       visit tasks_path
       fill_in 'search', with: test_title
-      select 'Doing', from: 'status'
+      select 'doing', from: 'status'
       click_button I18n.t('view.task.button.search')
       searched_task = Task.search(test_title).search_status('Doing')
       expect(page.all('tbody tr').count).to eq searched_task.count

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -11,7 +11,7 @@ describe 'タスク' do
       fill_in I18n.t('view.task.label.title'), with: title
       fill_in I18n.t('view.task.label.description'), with: 'テスト用タスクです'
       fill_in I18n.t('view.task.label.due_at'), with: '2020-01-01 00:00:00'
-      fill_in I18n.t('view.task.label.status'), with: 'waiting'
+      fill_in I18n.t('view.task.label.status'), with: 'Todo'
       fill_in I18n.t('view.task.label.priority'), with: '1'
       click_button I18n.t('view.task.button.submit')
       expect(Task.exists?(title: title)).to be true
@@ -23,7 +23,7 @@ describe 'タスク' do
       fill_in I18n.t('view.task.label.title'), with: title
       fill_in I18n.t('view.task.label.description'), with: 'テスト用タスクです'
       fill_in I18n.t('view.task.label.due_at'), with: '2020-01-01 00:00:00'
-      fill_in I18n.t('view.task.label.status'), with: 'waiting'
+      fill_in I18n.t('view.task.label.status'), with: 'Todo'
       fill_in I18n.t('view.task.label.priority'), with: '1'
       click_button I18n.t('view.task.button.submit')
       expect(page).to have_content I18n.t('view.task.message.created')
@@ -100,7 +100,7 @@ describe 'タスク' do
 
   context 'タスクを検索する' do
     let!(:task) { create(:task) }
-    let!(:working_task) { create_list(:working_task, 3)}
+    let!(:doing_task) { create_list(:doing_task, 3)}
     it '入力された文字列で検索をする' do
       visit tasks_path
       fill_in :search, with: test_title
@@ -117,18 +117,18 @@ describe 'タスク' do
 
     it 'ステータスで検索する' do
       visit tasks_path
-      select 'working', from: 'status'
+      select 'Doing', from: 'status'
       click_button I18n.t('view.task.button.search')
-      searched_task = Task.search_status('working')
+      searched_task = Task.search_status('Doing')
       expect(page.all('tbody tr').count).to eq searched_task.count
     end
 
     it 'タイトルとステータスで検索する' do
       visit tasks_path
       fill_in 'search', with: test_title
-      select 'working', from: 'status'
+      select 'Doing', from: 'status'
       click_button I18n.t('view.task.button.search')
-      searched_task = Task.search(test_title).search_status('working')
+      searched_task = Task.search(test_title).search_status('Doing')
       expect(page.all('tbody tr').count).to eq searched_task.count
     end
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -40,20 +40,20 @@ describe 'Task' do
   end
 
   describe '#search' do
-    let!(:task) { create(:task) }
-    context 'タイトルで検索する' do
-      let!(:sample_title_task) { create(:sample_title_task) }
+    let!(:come_up_task) { create(:task) }
+    context '#search_by_title' do
+      let!(:not_come_up_task) { create(:task, title: '検索にヒットしないタスク' ) }
       it '入力した文字列を含むタイトルを持つタスクを返す' do
-        expect(Task.search('テスト')).to include(task)
-        expect(Task.search('テスト')).not_to include(sample_title_task)
+        expect(Task.search_by_title('テスト')).to include(come_up_task)
+        expect(Task.search_by_title('テスト')).not_to include(not_come_up_task)
       end
     end
 
-    context 'ステータスで検索する' do
-      let!(:doing_task) { create(:doing_task) }
+    context '#search_by_status' do
+      let!(:not_come_up_task) { create(:task, status: 'doing') }
       it '指定されたステータスのタスクを返す' do
-        expect(Task.search_status('doing')).to include(doing_task)
-        expect(Task.search_status('doing')).not_to include(task)
+        expect(Task.search_by_status('todo')).to include(come_up_task)
+        expect(Task.search_by_status('todo')).not_to include(not_come_up_task)
       end
     end
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -50,10 +50,10 @@ describe 'Task' do
     end
 
     context 'ステータスで検索する' do
-      let!(:working_task) { create(:working_task) }
+      let!(:doing_task) { create(:doing_task) }
       it '指定されたステータスのタスクを返す' do
-        expect(Task.search_status('working')).to include(working_task)
-        expect(Task.search_status('working')).not_to include(task)
+        expect(Task.search_status('Doing')).to include(doing_task)
+        expect(Task.search_status('Doing')).not_to include(task)
       end
     end
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -38,4 +38,23 @@ describe 'Task' do
       expect(task.errors.details[:description].any? { |e| e[:error] == :too_long }).to be true
     end
   end
+
+  describe '#search' do
+    let!(:task) { create(:task) }
+    context 'タイトルで検索する' do
+      let!(:sample_title_task) { create(:sample_title_task) }
+      it '入力した文字列を含むタイトルを持つタスクを返す' do
+        expect(Task.search('テスト')).to include(task)
+        expect(Task.search('テスト')).not_to include(sample_title_task)
+      end
+    end
+
+    context 'ステータスで検索する' do
+      let!(:working_task) { create(:working_task) }
+      it '指定されたステータスのタスクを返す' do
+        expect(Task.search_status('working')).to include(working_task)
+        expect(Task.search_status('working')).not_to include(task)
+      end
+    end
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -52,8 +52,8 @@ describe 'Task' do
     context 'ステータスで検索する' do
       let!(:doing_task) { create(:doing_task) }
       it '指定されたステータスのタスクを返す' do
-        expect(Task.search_status('Doing')).to include(doing_task)
-        expect(Task.search_status('Doing')).not_to include(task)
+        expect(Task.search_status('doing')).to include(doing_task)
+        expect(Task.search_status('doing')).not_to include(task)
       end
     end
   end


### PR DESCRIPTION
## 何をやったか
タイトルとステータスで検索ができるようにしました。

なお、カリキュラムにある
> ステータス（未着手・着手中・完了）を追加してみよう

に関しては、https://github.com/tsumichan/todo-app/pull/9 ですでに対応済です。

また、[ステップ15](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9715-%E3%82%B9%E3%83%86%E3%83%BC%E3%82%BF%E3%82%B9%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%A6%E6%A4%9C%E7%B4%A2%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%82%88%E3%81%86)の後半の検索インデックスは別PRでやろうと思っています！


## こんな感じになりました

👇 **「猫」で検索をかける**
![image](https://user-images.githubusercontent.com/14156156/42798048-16e9a884-89cd-11e8-8df8-33bc10dbf035.png)

👇 **結果**
![image](https://user-images.githubusercontent.com/14156156/42798068-2b3b8d20-89cd-11e8-8a4d-69db6ecf34b3.png)


👇 **該当するタスクがない単語で検索をかける**
![image](https://user-images.githubusercontent.com/14156156/42798104-539428fe-89cd-11e8-8068-1583cad276ed.png)

👇 **結果**
![image](https://user-images.githubusercontent.com/14156156/42798119-617eb27c-89cd-11e8-843b-e5db1524ed2f.png)


👇 **「未着手」で検索**
![image](https://user-images.githubusercontent.com/14156156/42798169-92fdff88-89cd-11e8-8937-fb856e784e3c.png)

👇 **「着手」で検索**
![image](https://user-images.githubusercontent.com/14156156/42798195-a36cd466-89cd-11e8-96ab-45ba08d59e82.png)

👇 **「完了」で検索**
![image](https://user-images.githubusercontent.com/14156156/42798215-b178d5fa-89cd-11e8-86f5-8b69ac5f76f0.png)


## レビューポイント

- 余計なインデント、スペースがないか
- タイトルとステータスで検索する処理が正しく書けているかどうか
- テストが正しく書けているかどうか
- 無駄な記述の仕方をしていないか

## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:
