### PR TITLE
Taskモデルのstatusにindexを張りました

### DIFF
--- a/db/migrate/20180723034440_add_index_tasks_status.rb
+++ b/db/migrate/20180723034440_add_index_tasks_status.rb
@@ -1,0 +1,5 @@
+class AddIndexTasksStatus < ActiveRecord::Migration[5.2]
+  def change
+    add_index :tasks, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_26_024254) do
+ActiveRecord::Schema.define(version: 2018_07_23_034440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2018_06_26_024254) do
     t.integer "priority", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["status"], name: "index_tasks_on_status"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,11 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+require 'faker'
+
+10.times do |i|
+  Task.create(
+    title: "タスク#{i}",
+    description:  "これはタスク#{i}です",
+    priority: 0,
+    status: Faker::Number.between(0, 2),
+    due_at: Faker::Time.forward(60, :all)
+  )
+end


### PR DESCRIPTION
## 何をやったか
Taskモデルのstatusにindexを張り、検索が高速にできるようになりました。

## 検証
ランダムなstatusをもつテストデータを計5000個作成し、検索してみました

**index追加前**
検索にかかった時間=>**4.4ms**
```
Task Load (4.4ms)  SELECT "tasks".* FROM "tasks" WHERE "tasks"."status" = $1 ORDER BY "tasks"."created_at" DESC  [["status", "0"]]
```

**index追加後**
検索にかかった時間=>**3.1ms**
```
Task Load (3.1ms)  SELECT "tasks".* FROM "tasks" WHERE "tasks"."status" = $1 ORDER BY "tasks"."created_at" DESC  [["status", "0"]]
```


## レビューポイント
- 余計なインデント、スペースがないか
- index を張る処理が正しく書けているかどうか
- 無駄な記述の仕方をしていないか

## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:
