### PR TITLE
タスクを優先度順でソートする

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,8 +3,9 @@ class TasksController < ApplicationController
 
   def index
     @statuses = Task.statuses.map { |k, v| [t("enums.task.status.#{k}"), v]}
+    @priorities = [t("view.task.sort.priority_desc"), 0], [t("view.task.sort.priority_asc"), 1]
     @sorts = [t("view.task.sort.created_at"), 0], [t("view.task.sort.due_at"), 1]
-    @tasks = Task.search_by_title(params[:search]).search_by_status(params[:status]).sort_by_due_at(params[:sort])
+    @tasks = Task.search_by_title(params[:search]).search_by_status(params[:status]).sort_by_priority(params[:priority]).sort_by_due_at(params[:sort])
   end
   def new
     @task = Task.new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,9 +3,8 @@ class TasksController < ApplicationController
 
   def index
     @statuses = Task.statuses.map { |k, v| [t("enums.task.status.#{k}"), v]}
-    @priorities = [t("view.task.sort.priority_desc"), 0], [t("view.task.sort.priority_asc"), 1]
-    @sorts = [t("view.task.sort.created_at"), 0], [t("view.task.sort.due_at"), 1]
-    @tasks = Task.search_by_title(params[:search]).search_by_status(params[:status]).sort_by_priority(params[:priority]).sort_by_due_at(params[:sort])
+    @sorts = [t("view.task.sort.created_at"), 0], [t("view.task.sort.due_at"), 1], [t("view.task.sort.priority_desc"), 2], [t("view.task.sort.priority_asc"), 3]
+    @tasks = Task.search_by_title(params[:search]).search_by_status(params[:status]).sort_task(params[:sort])
   end
   def new
     @task = Task.new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,7 +4,7 @@ class TasksController < ApplicationController
   def index
     @statuses = Task.statuses.map { |k, v| [t("enums.task.status.#{k}"), v]}
     @sorts = [t("view.task.sort.created_at"), 0], [t("view.task.sort.due_at"), 1], [t("view.task.sort.priority_desc"), 2], [t("view.task.sort.priority_asc"), 3]
-    @tasks = Task.search_by_title(params[:search]).search_by_status(params[:status]).sort_task(params[:sort])
+    @tasks = Task.search_by_title(params[:search]).search_by_status(params[:status]).order_by(params[:sort])
   end
   def new
     @task = Task.new

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,24 +6,17 @@ class Task < ApplicationRecord
 
   scope :search_by_title, ->(word) { where('title LIKE ?', "%#{word}%") if word.present? }
   scope :search_by_status, ->(status) { where(status: status) if status.present? }
-  scope :sort_by_priority, ->(sort) {
-    if sort.present?
-      option = case sort.to_i
-           when 1
-             :asc
-           else
-             :desc
-           end
-      order(priority: option)
-    end
-  }
-  scope :sort_by_due_at, ->(sort) {
+  scope :sort_task, ->(sort) {
     option = case sort.to_i
-         when 1
-           { due_at: :asc }
-         else
-           { created_at: :desc }
-         end
+      when 1
+        { due_at: :asc }
+      when 2
+        { priority: :desc }
+      when 3
+        { priority: :asc }
+      else
+        { created_at: :desc }
+      end
     order(option)
   }
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,9 +2,21 @@ class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 100 }
   validates :description, length: { maximum: 255 }
   enum status: { todo: 0, doing: 1, done: 2 }
+  enum priority: { nothing: 0, low: 1, middle: 2, high: 3 }
 
   scope :search_by_title, ->(word) { where('title LIKE ?', "%#{word}%") if word.present? }
   scope :search_by_status, ->(status) { where(status: status) if status.present? }
+  scope :sort_by_priority, ->(sort) {
+    if sort.present?
+      option = case sort.to_i
+           when 1
+             :asc
+           else
+             :desc
+           end
+      order(priority: option)
+    end
+  }
   scope :sort_by_due_at, ->(sort) {
     option = case sort.to_i
          when 1

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,7 +6,7 @@ class Task < ApplicationRecord
 
   scope :search_by_title, ->(word) { where('title LIKE ?', "%#{word}%") if word.present? }
   scope :search_by_status, ->(status) { where(status: status) if status.present? }
-  scope :sort_task, ->(sort) {
+  scope :order_by, ->(sort) {
     option = case sort.to_i
       when 1
         { due_at: :asc }

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -5,7 +5,6 @@
   div
     = text_field_tag :search, params[:search]
     = select_tag :status, options_for_select(@statuses), include_blank: true
-    = select_tag :priority, options_for_select(@priorities), include_blank: true
     = select_tag :sort, options_for_select(@sorts)
     = submit_tag t('view.task.button.search')
 

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -5,6 +5,7 @@
   div
     = text_field_tag :search, params[:search]
     = select_tag :status, options_for_select(@statuses), include_blank: true
+    = select_tag :priority, options_for_select(@priorities), include_blank: true
     = select_tag :sort, options_for_select(@sorts)
     = submit_tag t('view.task.button.search')
 
@@ -22,7 +23,7 @@ table
             td = link_to task.title, task
             td = task.due_at
             td = task.status_i18n
-            td = task.priority
+            td = task.priority_i18n
             td = link_to t('view.task.link_text.edit'), edit_task_path(task.id)
             td = link_to t('view.task.link_text.delete'), task, method: :delete, data: {confirm: t('view.task.message.delete_confirm')}
     - else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,9 +6,6 @@ en:
         todo: "Todo"
         doing: "Doing"
         done: "Done"
-      sort:
-        due_at: "Sort by due at"
-        created_at: "Sort by created at"
   view:
     task:
       label:
@@ -35,6 +32,9 @@ en:
         delete: "Delte"
         add: "Add a new task"
         back: "Back"
+      sort:
+        due_at: "Sort by due at"
+        created_at: "Sort by created at"
   activerecord:
     errors:
       messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,11 @@ en:
         todo: "Todo"
         doing: "Doing"
         done: "Done"
+      priority:
+        nothing: ""
+        low: "★"
+        middle: "★★"
+        high: "★★★"
   view:
     task:
       label:
@@ -34,6 +39,8 @@ en:
       sort:
         due_at: "Sort by due at"
         created_at: "Sort by created at"
+        priority_desc: "Sort in descending order of high priority"
+        priority_asc: "Sort in descending order of low priority"
   activerecord:
     errors:
       messages:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,7 +30,6 @@ en:
         new: "New"
         edit: "Edit"
         delete: "Delte"
-        add: "Add a new task"
         back: "Back"
       sort:
         due_at: "Sort by due at"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,11 @@ ja:
         todo: "未着手"
         doing: "着手中"
         done: "完了"
+      priority:
+        nothing: ""
+        low: "★"
+        middle: "★★"
+        high: "★★★"
   view:
     task:
       label:
@@ -34,6 +39,8 @@ ja:
       sort:
         due_at: "終了期限が近い順でソートする"
         created_at: "作成日時が新しい順でソートする"
+        priority_desc: "優先度が高い順でソートする"
+        priority_asc: "優先度が低い順でソートする"
   activerecord:
     errors:
       messages:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,8 +4,9 @@ require 'faker'
   Task.create(
     title: "タスク#{i}",
     description:  "これはタスク#{i}です",
-    priority: 0,
+    priority: Faker::Number.between(0, 3),
     status: Faker::Number.between(0, 2),
-    due_at: Faker::Time.forward(60, :all)
+    due_at: Faker::Time.forward(60, :all),
+    created_at: Faker::Time.backward(30, :all)
   )
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -14,14 +14,6 @@ FactoryBot.define do
       created_at Date.parse('2000-01-01')
     end
 
-    factory :approaching_task do
-      due_at Date.parse('2000-01-01')
-    end
-
-    factory :not_approaching_task do
-      due_at Date.today
-    end
-
     factory :high_priority_task do
       priority 'high'
     end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
     end
 
     factory :not_approaching_task do
-      due_at Date.parse('2020-01-01')
+      due_at Date.today
     end
 
     factory :high_priority_task do

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     description 'テスト用タスクです'
     due_at Date.parse('2020-01-01')
     status 'todo'
-    priority '1'
+    priority 'nothing'
 
     factory :new_task do
       created_at Date.parse('2020-01-01')
@@ -12,6 +12,22 @@ FactoryBot.define do
 
     factory :old_task do
       created_at Date.parse('2000-01-01')
+    end
+
+    factory :approaching_task do
+      due_at Date.parse('2000-01-01')
+    end
+
+    factory :not_approaching_task do
+      due_at Date.parse('2020-01-01')
+    end
+
+    factory :high_priority_task do
+      priority 'high'
+    end
+
+    factory :low_priority_task do
+      priority 'low'
     end
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -77,7 +77,7 @@ describe 'タスク' do
   context '終了期限でソートするとき' do
     let! (:approaching_task) { create(:approaching_task) }
     let! (:not_approaching_task) { create(:not_approaching_task) }
-    it '終了期限が近い順タスクが上に来ること' do
+    it '終了期限が近いタスクが上に来ること' do
       visit tasks_path
       select I18n.t('view.task.sort.due_at'), from: 'sort'
       click_button I18n.t('view.task.button.search')
@@ -89,7 +89,7 @@ describe 'タスク' do
   context '作成日時でソートするとき' do
     let! (:new_task) { create(:new_task) }
     let! (:old_task) { create(:old_task) }
-    it '作成日時が新しい順タスクが上に来ること' do
+    it '作成日時が新しいタスクが上に来ること' do
       visit tasks_path
       select I18n.t('view.task.sort.created_at'), from: 'sort'
       click_button I18n.t('view.task.button.search')

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -101,7 +101,7 @@ describe 'タスク' do
   context '優先度でソートするとき' do
     let! (:high_priority_task) { create(:high_priority_task) }
     let! (:low_priority_task) { create(:low_priority_task) }
-    it '優先順が高い順タスクが上に来ること' do
+    it '優先順が高いタスクが上に来ること' do
       visit tasks_path
       select I18n.t('view.task.sort.priority_desc'), from: 'sort'
       click_button I18n.t('view.task.button.search')
@@ -109,7 +109,7 @@ describe 'タスク' do
       expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(low_priority_task.id))
     end
 
-    it '優先順が低い順タスクが上に来ること' do
+    it '優先順が低いタスクが上に来ること' do
       visit tasks_path
       select I18n.t('view.task.sort.priority_asc'), from: 'sort'
       click_button I18n.t('view.task.button.search')

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -12,7 +12,7 @@ describe 'タスク' do
       fill_in I18n.t('view.task.label.description'), with: 'テスト用タスクです'
       fill_in I18n.t('view.task.label.due_at'), with: '2020-01-01 00:00:00'
       fill_in I18n.t('view.task.label.status'), with: 'todo'
-      fill_in I18n.t('view.task.label.priority'), with: '1'
+      fill_in I18n.t('view.task.label.priority'), with: 'nothing'
       click_button I18n.t('view.task.button.submit')
       expect(Task.exists?(title: title)).to be true
       expect(page).to have_content title
@@ -24,7 +24,7 @@ describe 'タスク' do
       fill_in I18n.t('view.task.label.description'), with: 'テスト用タスクです'
       fill_in I18n.t('view.task.label.due_at'), with: '2020-01-01 00:00:00'
       fill_in I18n.t('view.task.label.status'), with: 'todo'
-      fill_in I18n.t('view.task.label.priority'), with: '1'
+      fill_in I18n.t('view.task.label.priority'), with: 'nothing'
       click_button I18n.t('view.task.button.submit')
       expect(page).to have_content I18n.t('view.task.message.created')
     end
@@ -75,22 +75,48 @@ describe 'タスク' do
   end
 
   context 'タスクをソートする' do
-    let! (:new_task) { create(:new_task, due_at: '2020-01-01') }
-    let! (:old_task) { create(:old_task, due_at: '2000-01-01') }
-    it '終了期限が近い順でソートする' do
-      visit tasks_path
-      select I18n.t('view.task.sort.due_at'), from: 'sort'
-      click_button I18n.t('view.task.button.search')
-      expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(old_task.id))
-      expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(new_task.id))
+    context '終了期限でソートする' do
+      let! (:approaching_task) { create(:approaching_task) }
+      let! (:not_approaching_task) { create(:not_approaching_task) }
+      it '終了期限が近い順でソートする' do
+        visit tasks_path
+        select I18n.t('view.task.sort.due_at'), from: 'sort'
+        click_button I18n.t('view.task.button.search')
+        expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(approaching_task.id))
+        expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(not_approaching_task.id))
+      end
     end
 
-    it '作成日時が新しい順でソートする' do
-      visit tasks_path
-      select I18n.t('view.task.sort.created_at'), from: 'sort'
-      click_button I18n.t('view.task.button.search')
-      expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(new_task.id))
-      expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(old_task.id))
+    context '作成日時でソートする' do
+      let! (:new_task) { create(:new_task) }
+      let! (:old_task) { create(:old_task) }
+      it '作成日時が新しい順でソートする' do
+        visit tasks_path
+        select I18n.t('view.task.sort.created_at'), from: 'sort'
+        click_button I18n.t('view.task.button.search')
+        expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(new_task.id))
+        expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(old_task.id))
+      end
+    end
+
+    context '優先度でソートする' do
+      let! (:high_priority_task) { create(:high_priority_task) }
+      let! (:low_priority_task) { create(:low_priority_task) }
+      it '優先順が高い順でソートする' do
+        visit tasks_path
+        select I18n.t('view.task.sort.priority_desc'), from: 'sort'
+        click_button I18n.t('view.task.button.search')
+        expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(high_priority_task.id))
+        expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(low_priority_task.id))
+      end
+
+      it '優先順が低い順でソートする' do
+        visit tasks_path
+        select I18n.t('view.task.sort.priority_asc'), from: 'sort'
+        click_button I18n.t('view.task.button.search')
+        expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(low_priority_task.id))
+        expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(high_priority_task.id))
+      end
     end
   end
 

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -75,8 +75,8 @@ describe 'タスク' do
   end
 
   context '終了期限でソートするとき' do
-    let! (:approaching_task) { create(:approaching_task) }
-    let! (:not_approaching_task) { create(:not_approaching_task) }
+    let! (:approaching_task) { create(:task) }
+    let! (:not_approaching_task) { create(:task, due_at: approaching_task.due_at + 1.day) }
     it '終了期限が近いタスクが上に来ること' do
       visit tasks_path
       select I18n.t('view.task.sort.due_at'), from: 'sort'

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -5,8 +5,8 @@ describe 'タスク' do
   let(:title_edited) { '変更用タスク' }
   let(:test_title) { 'テスト' }
 
-  context '新規のタスクを作成する' do
-    it '作成する' do
+  context '新規のタスクを作成するとき' do
+    it 'タスクが作成できること' do
       visit new_task_path
       fill_in I18n.t('view.task.label.title'), with: title
       fill_in I18n.t('view.task.label.description'), with: 'テスト用タスクです'
@@ -18,7 +18,7 @@ describe 'タスク' do
       expect(page).to have_content title
     end
 
-    it '作成完了のフラッシュメッセージを表示する' do
+    it '作成完了のフラッシュメッセージを表示すること' do
       visit new_task_path
       fill_in I18n.t('view.task.label.title'), with: title
       fill_in I18n.t('view.task.label.description'), with: 'テスト用タスクです'
@@ -30,9 +30,9 @@ describe 'タスク' do
     end
   end
 
-  context '既存のタスクを更新する' do
+  context '既存のタスクを更新するとき' do
     let(:task) { create(:task) }
-    it '変更する' do
+    it '加えた変更を更新すること' do
       visit edit_task_path(task.id)
       fill_in I18n.t('view.task.label.title'), with: title_edited
       click_button I18n.t('view.task.button.submit')
@@ -40,7 +40,7 @@ describe 'タスク' do
       expect(page).to have_content title_edited
     end
 
-    it '更新完了のフラッシュメッセージを表示する' do
+    it '更新完了のフラッシュメッセージを表示すること' do
       visit edit_task_path(task.id)
       fill_in I18n.t('view.task.label.title'), with: '変更タスク'
       click_button I18n.t('view.task.button.submit')
@@ -48,103 +48,105 @@ describe 'タスク' do
     end
   end
 
-  context '既存のタスクを削除する' do
+  context '既存のタスクを削除するとき' do
     let!(:task) { create(:task) }
-    it '削除する' do
+    it 'タスクを削除できること' do
       visit tasks_path
       click_link I18n.t('view.task.link_text.delete')
       expect(Task.exists?(title: title)).not_to be true
       expect(page).not_to have_content title
     end
 
-    it '削除完了のフラッシュメッセージを表示する' do
+    it '削除完了のフラッシュメッセージを表示すること' do
       visit tasks_path
       click_link I18n.t('view.task.link_text.delete')
       expect(page).to have_content I18n.t('view.task.message.deleted')
     end
   end
 
-  context 'タスクを作成日時の降順で表示する' do
+  context 'タスクを作成日時の降順で表示するとき' do
     let! (:new_task) { create(:new_task) }
     let! (:old_task) { create(:old_task) }
-    it 'タスクを降順でソートする' do
+    it 'タスクを降順でソートすること' do
       visit tasks_path
       expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(new_task.id))
       expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(old_task.id))
     end
   end
 
-  context 'タスクをソートする' do
-    context '終了期限でソートする' do
-      let! (:approaching_task) { create(:approaching_task) }
-      let! (:not_approaching_task) { create(:not_approaching_task) }
-      it '終了期限が近い順でソートする' do
-        visit tasks_path
-        select I18n.t('view.task.sort.due_at'), from: 'sort'
-        click_button I18n.t('view.task.button.search')
-        expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(approaching_task.id))
-        expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(not_approaching_task.id))
-      end
-    end
-
-    context '作成日時でソートする' do
-      let! (:new_task) { create(:new_task) }
-      let! (:old_task) { create(:old_task) }
-      it '作成日時が新しい順でソートする' do
-        visit tasks_path
-        select I18n.t('view.task.sort.created_at'), from: 'sort'
-        click_button I18n.t('view.task.button.search')
-        expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(new_task.id))
-        expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(old_task.id))
-      end
-    end
-
-    context '優先度でソートする' do
-      let! (:high_priority_task) { create(:high_priority_task) }
-      let! (:low_priority_task) { create(:low_priority_task) }
-      it '優先順が高い順でソートする' do
-        visit tasks_path
-        select I18n.t('view.task.sort.priority_desc'), from: 'sort'
-        click_button I18n.t('view.task.button.search')
-        expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(high_priority_task.id))
-        expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(low_priority_task.id))
-      end
-
-      it '優先順が低い順でソートする' do
-        visit tasks_path
-        select I18n.t('view.task.sort.priority_asc'), from: 'sort'
-        click_button I18n.t('view.task.button.search')
-        expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(low_priority_task.id))
-        expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(high_priority_task.id))
-      end
+  context '終了期限でソートするとき' do
+    let! (:approaching_task) { create(:approaching_task) }
+    let! (:not_approaching_task) { create(:not_approaching_task) }
+    it '終了期限が近い順タスクが上に来ること' do
+      visit tasks_path
+      select I18n.t('view.task.sort.due_at'), from: 'sort'
+      click_button I18n.t('view.task.button.search')
+      expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(approaching_task.id))
+      expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(not_approaching_task.id))
     end
   end
 
-  context 'タスクを検索する' do
+  context '作成日時でソートするとき' do
+    let! (:new_task) { create(:new_task) }
+    let! (:old_task) { create(:old_task) }
+    it '作成日時が新しい順タスクが上に来ること' do
+      visit tasks_path
+      select I18n.t('view.task.sort.created_at'), from: 'sort'
+      click_button I18n.t('view.task.button.search')
+      expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(new_task.id))
+      expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(old_task.id))
+    end
+  end
+
+  context '優先度でソートするとき' do
+    let! (:high_priority_task) { create(:high_priority_task) }
+    let! (:low_priority_task) { create(:low_priority_task) }
+    it '優先順が高い順タスクが上に来ること' do
+      visit tasks_path
+      select I18n.t('view.task.sort.priority_desc'), from: 'sort'
+      click_button I18n.t('view.task.button.search')
+      expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(high_priority_task.id))
+      expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(low_priority_task.id))
+    end
+
+    it '優先順が低い順タスクが上に来ること' do
+      visit tasks_path
+      select I18n.t('view.task.sort.priority_asc'), from: 'sort'
+      click_button I18n.t('view.task.button.search')
+      expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(low_priority_task.id))
+      expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(high_priority_task.id))
+    end
+  end
+
+  context 'タスクをタイトルで検索するとき' do
     let!(:task) { create(:task) }
-    it '入力された文字列で検索をする' do
+    it '入力された文字列でタスクを検索できること' do
       visit tasks_path
       fill_in :search, with: test_title
       click_button I18n.t('view.task.button.search')
       expect(page).to have_content test_title
     end
 
-    it 'マッチするものがない場合、マッチするものがなかったことを知らせる' do
+    it 'マッチするものがない場合、マッチするものがなかったことを知らせること' do
       visit tasks_path
       fill_in :search, with: 'サンプル'
       click_button I18n.t('view.task.button.search')
       expect(page).to have_content I18n.t('view.task.message.no_match_task')
     end
+  end
 
-    it 'ステータスで検索する' do
+  context 'タスクをステータスで検索するとき' do
+    it '指定したステータスを持つタスクを検索すること' do
       visit tasks_path
       select I18n.t('enums.task.status.doing'), from: 'status'
       click_button I18n.t('view.task.button.search')
       searched_task = Task.search_by_status('doing')
       expect(page.all('tbody tr').count).to eq searched_task.count
     end
+  end
 
-    it 'タイトルとステータスで検索する' do
+  context 'タイトルとステータスで検索するとき' do
+    it '指定したタイトルとステータスを持つタスクを検索すること' do
       visit tasks_path
       fill_in 'search', with: test_title
       select I18n.t('enums.task.status.doing'), from: 'status'


### PR DESCRIPTION
## 何をやったか
タスクを優先度順でソートできるようにしました。

## こうなりました
（一応今回も作成日時を一時的に表示しています）

👇 **これが**
![image](https://user-images.githubusercontent.com/14156156/43135141-5dda124e-8f7f-11e8-9874-9df70f2c9800.png)

👇 **こう**
![image](https://user-images.githubusercontent.com/14156156/43135162-6c423050-8f7f-11e8-865d-b37ac64a157e.png)

👇 **これが**
![image](https://user-images.githubusercontent.com/14156156/43135205-9307d30c-8f7f-11e8-821a-0d4cbc5a6a54.png)

👇 **こう**
![image](https://user-images.githubusercontent.com/14156156/43135220-a09674ec-8f7f-11e8-9b2a-f4d22d8b0a15.png)

## レビューポイント

- 余計なインデント、スペースがないか
- 優先度順でソートする処理が正しく書けているかどうか
- テストが正しく書けているかどうか
- 無駄な記述の仕方をしていないか


## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:
