### PR TITLE
トップページにデザインをあてた

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ gem 'slim-rails'
 gem 'http_accept_language'
 gem 'enum_help'
 gem 'kaminari'
+gem 'bootstrap'
+gem 'jquery-rails'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,9 +47,15 @@ GEM
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
+    autoprefixer-rails (9.0.0)
+      execjs
     bindex (0.5.0)
     bootsnap (1.3.0)
       msgpack (~> 1.0)
+    bootstrap (4.1.3)
+      autoprefixer-rails (>= 6.0.3)
+      popper_js (>= 1.12.9, < 2)
+      sass (>= 3.5.2)
     builder (3.2.3)
     byebug (10.0.2)
     capybara (3.2.1)
@@ -97,6 +103,10 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jquery-rails (4.3.3)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -133,6 +143,7 @@ GEM
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     pg (1.0.0)
+    popper_js (1.14.3)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -257,6 +268,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
+  bootstrap
   byebug
   capybara (>= 2.15, < 4.0)
   chromedriver-helper
@@ -267,6 +279,7 @@ DEPENDENCIES
   faker
   http_accept_language
   jbuilder (~> 2.5)
+  jquery-rails
   kaminari
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,4 +13,7 @@
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks
+//= require jquery3
+//= require popper
+//= require bootstrap-sprockets
 //= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,4 @@
  *= require_tree .
  *= require_self
  */
+ @import "bootstrap";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,6 @@
 #new-task-button {
   margin: 20px 0;
 }
+.pagination {
+  justify-content: center;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,3 +14,7 @@
  *= require_self
  */
  @import "bootstrap";
+
+#new-task-button {
+  margin: 20px 0;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,9 +15,13 @@
  */
  @import "bootstrap";
 
+// トップページ
 #new-task-button {
   margin: 20px 0;
 }
 .pagination {
   justify-content: center;
+}
+.delete-link {
+  color: red;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,7 +13,7 @@
  *= require_tree .
  *= require_self
  */
- @import "bootstrap";
+@import "bootstrap";
 
 // トップページ
 #new-task-button {

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -1,0 +1,2 @@
+li.page-item.disabled
+  = link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link'

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -1,0 +1,6 @@
+- if page.current?
+  li.page-item.active
+    = content_tag :a, page, data: { remote: remote }, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'
+- else
+  li.page-item
+    = link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)), class: 'page-link'

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,0 +1,12 @@
+= paginator.render do
+  nav
+    ul.pagination
+      == first_page_tag unless current_page.first?
+      == prev_page_tag unless current_page.first?
+      - each_page do |page|
+        - if page.left_outer? || page.right_outer? || page.inside_window?
+          == page_tag page
+        - elsif !page.was_truncated?
+          == gap_tag
+      == next_page_tag unless current_page.last?
+      == last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -40,7 +40,7 @@ div.container
         h4 タスクを検索する
         div.form-group
           label.small タイトルで検索する
-          = text_field_tag :search, params[:search], placeholder: 'タイトルで検索', class: 'form-control'
+          = text_field_tag :search, params[:search], class: 'form-control'
         div.form-group
           label.small ステータスで絞り込み
           = select_tag :status, options_for_select(@statuses), prompt: 'ステータス（未選択）', class: 'form-control'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,31 +1,44 @@
-- flash.each do |key, value|
-  = content_tag(:div, value, class: key)
+nav.navbar.navbar-expand-lg.navbar-light.bg-light
+  a.navbar-brand href="#" Todo App
+  button.navbar-toggler type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"
+    span.navbar-toggler-icon
+  div.collapse.navbar-collapse#navbarSupportedContent
+    ul.navbar-nav.mr-auto
+      li.nav-item.active
+        a.nav-link href="#" Home
 
-= form_tag tasks_path, :method => 'get' do
-  div
-    = text_field_tag :search, params[:search]
-    = select_tag :status, options_for_select(@statuses), include_blank: true
-    = select_tag :sort, options_for_select(@sorts)
-    = submit_tag t('views.task.button.search')
-
-table
-  thead
-    tr
-      th = t('views.task.label.title')
-      th = t('views.task.label.due_at')
-      th = t('views.task.label.status')
-      th = t('views.task.label.priority')
-    - if @tasks.exists?
-      tbody
-        - @tasks.each do |task|
+div.container
+  div.row
+    - flash.each do |key, value|
+      = content_tag(:div, value, class: key)
+  div.row
+    div.col-lg-8
+      table.table.table-hover
+        thead.thead-dark
           tr
-            td = link_to task.title, task
-            td = task.due_at
-            td = task.status_i18n
-            td = task.priority_i18n
-            td = link_to t('views.task.link_text.edit'), edit_task_path(task.id)
-            td = link_to t('views.task.link_text.delete'), task, method: :delete, data: {confirm: t('views.task.message.delete_confirm')}
-    - else
-      div = t('views.task.message.no_match_task')
-= paginate @tasks
-div = link_to t('views.task.link_text.new'), new_task_path
+            th = t('views.task.label.title')
+            th = t('views.task.label.due_at')
+            th = t('views.task.label.status')
+            th = t('views.task.label.priority')
+            th
+            th
+          - if @tasks.exists?
+            tbody
+              - @tasks.each do |task|
+                tr
+                  td = link_to task.title, task
+                  td = task.due_at
+                  td = task.status_i18n
+                  td = task.priority_i18n
+                  td = link_to t('views.task.link_text.edit'), edit_task_path(task.id)
+                  td = link_to t('views.task.link_text.delete'), task, method: :delete, data: {confirm: t('views.task.message.delete_confirm')}
+          - else
+            div = t('views.task.message.no_match_task')
+      = paginate @tasks
+    div.col-lg-4
+      = link_to t('views.task.link_text.new'), new_task_path, class: 'btn btn-primary'
+      = form_tag tasks_path, :method => 'get' do
+        div.form-group = text_field_tag :search, params[:search], placeholder: 'タイトルで検索', class: 'form-control'
+        div.form-group = select_tag :status, options_for_select(@statuses), prompt: 'ステータス（未選択）', class: 'form-control'
+        div.form-group = select_tag :sort, options_for_select(@sorts), class: 'form-control'
+        div.form-group = submit_tag t('views.task.button.search'), class: 'btn btn-outline-secondary right'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -31,7 +31,7 @@ div.container
                   td = task.status_i18n
                   td = task.priority_i18n
                   td = link_to t('views.task.link_text.edit'), edit_task_path(task.id)
-                  td = link_to t('views.task.link_text.delete'), task, method: :delete, data: {confirm: t('views.task.message.delete_confirm')}
+                  td = link_to t('views.task.link_text.delete'), task, method: :delete, data: {confirm: t('views.task.message.delete_confirm')}, class: 'delete-link'
           - else
             div = t('views.task.message.no_match_task')
       = paginate @tasks

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -41,4 +41,4 @@ div.container
         div.form-group = text_field_tag :search, params[:search], placeholder: 'タイトルで検索', class: 'form-control'
         div.form-group = select_tag :status, options_for_select(@statuses), prompt: 'ステータス（未選択）', class: 'form-control'
         div.form-group = select_tag :sort, options_for_select(@sorts), class: 'form-control'
-        div.form-group = submit_tag t('views.task.button.search'), class: 'btn btn-outline-secondary right'
+        div.form-group = submit_tag t('views.task.button.search'), class: 'btn btn-outline-secondary'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -13,6 +13,8 @@ div.container
       = content_tag(:div, value, class: key)
   div.row
     div.col-lg-8
+      div.text-right
+        = link_to t('views.task.link_text.new'), new_task_path, class: 'btn btn-primary', id: 'new-task-button'
       table.table.table-hover
         thead.thead-light
           tr
@@ -35,10 +37,16 @@ div.container
           - else
             div = t('views.task.message.no_match_task')
       = paginate @tasks
-    div.col-lg-4
-      = link_to t('views.task.link_text.new'), new_task_path, class: 'btn btn-primary', id: 'new-task-button'
+    div.col-lg-4.mt-4
       = form_tag tasks_path, :method => 'get' do
-        div.form-group = text_field_tag :search, params[:search], placeholder: 'タイトルで検索', class: 'form-control'
-        div.form-group = select_tag :status, options_for_select(@statuses), prompt: 'ステータス（未選択）', class: 'form-control'
-        div.form-group = select_tag :sort, options_for_select(@sorts), class: 'form-control'
+        h4 タスクを検索する
+        div.form-group
+          label.small タイトルで検索する
+          = text_field_tag :search, params[:search], placeholder: 'タイトルで検索', class: 'form-control'
+        div.form-group
+          label.small ステータスで絞り込み
+          = select_tag :status, options_for_select(@statuses), prompt: 'ステータス（未選択）', class: 'form-control'
+        div.form-group
+          label.small ソートする
+          = select_tag :sort, options_for_select(@sorts), class: 'form-control'
         div.form-group = submit_tag t('views.task.button.search'), class: 'btn btn-outline-secondary'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,11 +1,12 @@
 nav.navbar.navbar-expand-lg.navbar-light.bg-light
-  a.navbar-brand href="#{root_path}" Todo App
   button.navbar-toggler type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"
     span.navbar-toggler-icon
   div.collapse.navbar-collapse#navbarSupportedContent
+  = link_to 'Todo App', root_path, class: 'navbar-brand'
+  div.collapse.navbar-collapse
     ul.navbar-nav.mr-auto
       li.nav-item.active
-        a.nav-link href="#{root_path}" Home
+        = link_to 'Home', root_path, class: 'nav-link'
 
 div.container
   div.row

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,11 +1,11 @@
 nav.navbar.navbar-expand-lg.navbar-light.bg-light
-  a.navbar-brand href="#" Todo App
+  a.navbar-brand href="#{root_path}" Todo App
   button.navbar-toggler type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"
     span.navbar-toggler-icon
   div.collapse.navbar-collapse#navbarSupportedContent
     ul.navbar-nav.mr-auto
       li.nav-item.active
-        a.nav-link href="#" Home
+        a.nav-link href="#{root_path}" Home
 
 div.container
   div.row

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -36,7 +36,7 @@ div.container
             div = t('views.task.message.no_match_task')
       = paginate @tasks
     div.col-lg-4.mt-4
-      = form_tag tasks_path, :method => 'get' do
+      = form_tag tasks_path, method: :get do
         h4 タスクを検索する
         div.form-group
           label.small タイトルで検索する

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -14,7 +14,7 @@ div.container
   div.row
     div.col-lg-8
       table.table.table-hover
-        thead.thead-dark
+        thead.thead-light
           tr
             th = t('views.task.label.title')
             th = t('views.task.label.due_at')

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -36,7 +36,7 @@ div.container
             div = t('views.task.message.no_match_task')
       = paginate @tasks
     div.col-lg-4
-      = link_to t('views.task.link_text.new'), new_task_path, class: 'btn btn-primary'
+      = link_to t('views.task.link_text.new'), new_task_path, class: 'btn btn-primary', id: 'new-task-button'
       = form_tag tasks_path, :method => 'get' do
         div.form-group = text_field_tag :search, params[:search], placeholder: 'タイトルで検索', class: 'form-control'
         div.form-group = select_tag :status, options_for_select(@statuses), prompt: 'ステータス（未選択）', class: 'form-control'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,7 +1,4 @@
 nav.navbar.navbar-expand-lg.navbar-light.bg-light
-  button.navbar-toggler type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation"
-    span.navbar-toggler-icon
-  div.collapse.navbar-collapse#navbarSupportedContent
   = link_to 'Todo App', root_path, class: 'navbar-brand'
   div.collapse.navbar-collapse
     ul.navbar-nav.mr-auto

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -37,10 +37,10 @@ ja:
         delete: "削除"
         back: "戻る"
       sort:
-        due_at: "終了期限が近い順でソートする"
-        created_at: "作成日時が新しい順でソートする"
-        priority_desc: "優先度が高い順でソートする"
-        priority_asc: "優先度が低い順でソートする"
+        due_at: "終了期限が近い順"
+        created_at: "作成日時が新しい順"
+        priority_desc: "優先度が高い順"
+        priority_asc: "優先度が低い順"
     pagination:
       first: "&laquo;"
       last: "&raquo;"

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -161,7 +161,7 @@ describe 'タスク' do
     let!(:tasks) { create_list(:task, 50) }
     it 'ページネーションが表示されること' do
       visit tasks_path
-      expect(page.all('nav span')[1]).to have_link('2', href: '/?page=2')
+      expect(page.all('nav ul')[1]).to have_link('2', href: '/?page=2')
     end
 
     it '1ページあたり15件のタスクが表示されること' do


### PR DESCRIPTION
## 何をやったか
トップページにデザインをあてていい感じにしました。
【このPRで**やった**こと】
- 全体的にいい感じにした
- 上部にあったソート・検索のフォームをタスク一覧の右側に移した
- ソート・検索のフォームに placeholder を追加してわかりやすくした
- pagination(kaminari) にデザインをあてた（中央寄せにした）

【このPRで**やらない**こと】
- 新規タスク作成・編集・詳細画面へのスタイルの適用
- flashメッセージへのスタイルの適用
- 終了期限のフォーマットをいい感じにする

**Before**
![image](https://user-images.githubusercontent.com/14156156/43387402-4f4a469e-9421-11e8-84e3-52a7eb982fe4.png)


**After**
![image](https://user-images.githubusercontent.com/14156156/43387158-adb37c74-9420-11e8-8db6-fa7612b322b6.png)

すごい！！！！！！！

## レビューポイント
- 余計なインデント、スペースがないか
- Bootstrapを導入する処理が正しく書けているかどうか
- テストが正しく書けているかどうか
- 無駄な記述の仕方をしていないか

## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:
