### PR TITLE
ユーザーの新規作成・編集・削除ができるようにした

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,4 +4,32 @@ class Admin::UsersController < ApplicationController
   def index
     @users = User.all.page(params[:page])
   end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to admin_users_path, flash: { success: 'ユーザー作成が完了しました' }
+    else
+      render :new
+    end
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :password, :role)
+  end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -12,7 +12,7 @@ class Admin::UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to admin_users_path, flash: { success: 'ユーザー作成が完了しました' }
+      redirect_to admin_users_path, flash: { success: t('views.user.message.created') }
     else
       render :new
     end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -19,9 +19,16 @@ class Admin::UsersController < ApplicationController
   end
 
   def edit
+    @user = User.find(params[:id])
   end
 
   def update
+    @user = User.find(params[:id])
+    if @user.update(user_params)
+      redirect_to admin_users_path, flash: { success: t('views.user.message.updated') }
+    else
+      render :edit
+    end
   end
 
   def destroy

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -32,6 +32,9 @@ class Admin::UsersController < ApplicationController
   end
 
   def destroy
+    @user = User.find(params[:id])
+    @user.destroy
+    redirect_to admin_users_path, flash: { success: t('views.user.message.deleted') }
   end
 
   private

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,5 @@
+module UsersHelper
+  def role_select_options
+    User.roles.keys.map { |k| [t("enums.user.role.#{k}"), k] }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
   enum role: { common: 0, admin: 1 }
 
-  validates :name, presence: true, length: { minimum: 5, maximum: 25 }, uniqueness: { case_sensitive: false }, on: :create
+  validates :name, presence: true, length: { minimum: 1, maximum: 25 }, uniqueness: { case_sensitive: false }, on: :create
   validates :password, presence: true, length: { minimum:8, maximum: 100 }, on: :create
   validates :role, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,8 @@ class User < ApplicationRecord
   has_secure_password
   has_many :tasks, dependent: :destroy
   enum role: { common: 0, admin: 1 }
+
+  validates :name, presence: true, length: { minimum: 5, maximum: 25 }, uniqueness: { case_sensitive: false }
+  validates :password, presence: true, length: { minimum:8, maximum: 100 }
+  validates :role, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
   enum role: { common: 0, admin: 1 }
 
-  validates :name, presence: true, length: { minimum: 5, maximum: 25 }, uniqueness: { case_sensitive: false }
-  validates :password, presence: true, length: { minimum:8, maximum: 100 }
+  validates :name, presence: true, length: { minimum: 5, maximum: 25 }, uniqueness: { case_sensitive: false }, on: :create
+  validates :password, presence: true, length: { minimum:8, maximum: 100 }, on: :create
   validates :role, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
   has_secure_password
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
   enum role: { common: 0, admin: 1 }
 end

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,11 +1,3 @@
-div.row
-  div.col-lg-8.mx-auto
-    - if @user.errors.any?
-      div.alert.alert-danger.alert-dismissible.fade.show
-        ul
-          - @user.errors.full_messages.each do |message|
-            li = message
-
 div.text-center
   h1 = 'ユーザーを編集する'
 div.row

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,0 +1,25 @@
+div.row
+  div.col-lg-8.mx-auto
+    - if @user.errors.any?
+      div.alert.alert-danger.alert-dismissible.fade.show
+        ul
+          - @user.errors.full_messages.each do |message|
+            li = message
+
+div.text-center
+  h1 = 'ユーザーを編集する'
+div.row
+  div.col-lg-8.mx-auto
+    = form_for [:admin, @user] do |f|
+      div.form-group.required
+        = f.label :name, 'user name', class: 'font-weight-bold control-label'
+        = f.text_field :name, class: 'form-control', readonly: true
+      div.form-group.required
+        = f.label :password, 'password', class: 'font-weight-bold control-label'
+        = f.password_field :password, class: 'form-control', readonly: true
+      div.form-group.required
+        = f.label :role, 'role', class: 'font-weight-bold control-label'
+        = f.select :role, role_select_options, { include_blank: false }, { class: 'form-control'}
+      div.form-group.text-center
+        = link_to t('views.user.link_text.back'), :back, class: 'btn btn-light btn-lg mx-5'
+        = f.submit t('views.button.submit'), class: 'btn btn-primary btn-lg mx-5'

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -11,14 +11,14 @@ div.text-center
 div.row
   div.col-lg-8.mx-auto
     = form_for [:admin, @user] do |f|
-      div.form-group.required
-        = f.label :name, 'user name', class: 'font-weight-bold control-label'
+      div.form-group
+        = f.label :name, t('views.user.label.user_name'), class: 'font-weight-bold control-label'
         = f.text_field :name, class: 'form-control', readonly: true
-      div.form-group.required
-        = f.label :password, 'password', class: 'font-weight-bold control-label'
+      div.form-group
+        = f.label :password, t('views.user.label.password'), class: 'font-weight-bold control-label'
         = f.password_field :password, class: 'form-control', readonly: true
       div.form-group.required
-        = f.label :role, 'role', class: 'font-weight-bold control-label'
+        = f.label :role, t('views.user.label.role'), class: 'font-weight-bold control-label'
         = f.select :role, role_select_options, { include_blank: false }, { class: 'form-control'}
       div.form-group.text-center
         = link_to t('views.user.link_text.back'), :back, class: 'btn btn-light btn-lg mx-5'

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -20,5 +20,5 @@ div.row
             td = user.role_i18n
             td = user.tasks.count
             td = link_to t('views.user.link_text.edit'), edit_admin_user_path(user.id)
-            td = link_to t('views.user.link_text.delete'), href='#'
+            td = link_to t('views.user.link_text.delete'), admin_user_path(user.id), method: :delete, data: {confirm: t('views.user.message.delete_confirm')}, class: 'delete-link'
     = paginate @users

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -2,7 +2,7 @@ div.row
   div.col-lg-12
     h2 ユーザー 一覧
     div.text-right
-      = link_to t('views.user.link_text.new'), href='#', class: 'btn btn-primary', id: 'new-task-button'
+      = link_to t('views.user.link_text.new'), new_admin_user_path, class: 'btn btn-primary', id: 'new-task-button'
     table.table.table-hover
       thead.thead-light
         tr

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -19,6 +19,6 @@ div.row
             td = user.name
             td = user.role_i18n
             td = user.tasks.count
-            td = link_to t('views.user.link_text.edit'), href='#'
+            td = link_to t('views.user.link_text.edit'), edit_admin_user_path(user.id)
             td = link_to t('views.user.link_text.delete'), href='#'
     = paginate @users

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -12,13 +12,13 @@ div.row
   div.col-lg-8.mx-auto
     = form_for [:admin, @user] do |f|
       div.form-group.required
-        = f.label :name, 'user name', class: 'font-weight-bold control-label'
+        = f.label :name, t('views.user.label.user_name'), class: 'font-weight-bold control-label'
         = f.text_field :name, class: 'form-control', required: true
       div.form-group.required
-        = f.label :password, 'password', class: 'font-weight-bold control-label'
+        = f.label :password, t('views.user.label.password'), class: 'font-weight-bold control-label'
         = f.password_field :password, class: 'form-control', required: true
       div.form-group.required
-        = f.label :role, 'role', class: 'font-weight-bold control-label'
+        = f.label :role, t('views.user.label.role'), class: 'font-weight-bold control-label'
         = f.select :role, role_select_options, {}, { class: 'form-control', required: true }
       div.form-group.text-center
         = link_to t('views.user.link_text.back'), :back, class: 'btn btn-light btn-lg mx-5'

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,3 +1,5 @@
+div.text-center
+  h1 = 'ユーザーを作成する'
 div.row
   div.col-lg-8.mx-auto
     - if @user.errors.any?
@@ -5,9 +7,6 @@ div.row
         ul
           - @user.errors.full_messages.each do |message|
             li = message
-
-div.text-center
-  h1 = 'ユーザーを作成する'
 div.row
   div.col-lg-8.mx-auto
     = form_for [:admin, @user] do |f|

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -21,5 +21,5 @@ div.row
         = f.label :role, 'role', class: 'font-weight-bold control-label'
         = f.select :role, role_select_options, {}, { class: 'form-control', required: true }
       div.form-group.text-center
-        = link_to t('views.task.link_text.back'), :back, class: 'btn btn-light btn-lg mx-5'
-        = f.submit t('views.task.button.submit'), class: 'btn btn-primary btn-lg mx-5'
+        = link_to t('views.user.link_text.back'), :back, class: 'btn btn-light btn-lg mx-5'
+        = f.submit t('views.button.submit'), class: 'btn btn-primary btn-lg mx-5'

--- a/app/views/admin/users/new.html.slim
+++ b/app/views/admin/users/new.html.slim
@@ -1,0 +1,25 @@
+div.row
+  div.col-lg-8.mx-auto
+    - if @user.errors.any?
+      div.alert.alert-danger.alert-dismissible.fade.show
+        ul
+          - @user.errors.full_messages.each do |message|
+            li = message
+
+div.text-center
+  h1 = 'ユーザーを作成する'
+div.row
+  div.col-lg-8.mx-auto
+    = form_for [:admin, @user] do |f|
+      div.form-group.required
+        = f.label :name, 'user name', class: 'font-weight-bold control-label'
+        = f.text_field :name, class: 'form-control', required: true
+      div.form-group.required
+        = f.label :password, 'password', class: 'font-weight-bold control-label'
+        = f.password_field :password, class: 'form-control', required: true
+      div.form-group.required
+        = f.label :role, 'role', class: 'font-weight-bold control-label'
+        = f.select :role, role_select_options, {}, { class: 'form-control', required: true }
+      div.form-group.text-center
+        = link_to t('views.task.link_text.back'), :back, class: 'btn btn-light btn-lg mx-5'
+        = f.submit t('views.task.button.submit'), class: 'btn btn-primary btn-lg mx-5'

--- a/app/views/tasks/_form.html.slim
+++ b/app/views/tasks/_form.html.slim
@@ -30,7 +30,7 @@ div.row
         = f.select :priority, priority_select_options, {}, { class: 'form-control' }
       div.form-group.text-center
         = link_to t('views.task.link_text.back'), :back, class: 'btn btn-light btn-lg mx-5'
-        = f.submit t('views.task.button.submit'), class: 'btn btn-primary btn-lg mx-5'
+        = f.submit t('views.button.submit'), class: 'btn btn-primary btn-lg mx-5'
 
 javascript:
   $(function () {

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -37,4 +37,4 @@ div.row
       div.form-group
         label.small ソートする
         = select_tag :sort, options_for_select(@sorts), class: 'form-control'
-      div.form-group = submit_tag t('views.task.button.search'), class: 'btn btn-outline-secondary'
+      div.form-group = submit_tag t('views.button.search'), class: 'btn btn-outline-secondary'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,10 @@ en:
         log_out_success: "Logout Successed"
         log_in_failed: "Login Failed"
         require_login: "Please Login"
+        created: "Created a new user"
+        updated: "Updated a user"
+        deleted: "Deleted a user"
+        delete_confirm: "Are you sure you want to delte this task?"
       link_text:
         new: "New"
         edit: "Edit"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,9 @@ en:
         task_list: "Task List"
         log_out: "Log Out"
         admin_page: "Admin Page"
+    button:
+      submit: "Submit"
+      search: "Search"
     task:
       label:
         title: "Title"
@@ -28,9 +31,6 @@ en:
         due_at: "Due at"
         status: "Status"
         priority: "Priority"
-      button:
-        submit: "Submit"
-        search: "Search"
       title:
         new: "Create new task"
         edit: "Edit the task"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,6 +21,9 @@ ja:
         task_list: "タスク一覧"
         log_out: "ログアウト"
         admin_page: "管理画面"
+    button:
+      submit: "登録"
+      search: "検索"
     task:
       label:
         title: "タスク名"
@@ -28,9 +31,6 @@ ja:
         due_at: "終了期限"
         status: "ステータス"
         priority: "優先度"
-      button:
-        submit: "登録"
-        search: "検索"
       title:
         new: "タスクを追加する"
         edit: "タスクを編集する"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -69,6 +69,10 @@ ja:
         log_out_success: "ログアウトしました"
         log_in_failed: "ログインできませんでした"
         require_login: "ログインしてください"
+        created: "ユーザーを作成しました"
+        updated: "ロールを更新しました"
+        deleted: "ユーザーを削除しました"
+        delete_confirm: "本当に削除しますか？"
       link_text:
         new: "新規ユーザーを作成"
         edit: "編集"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
   post '/login',   to: 'sessions#create'
   delete 'logout', to: 'sessions#destroy'
   namespace :admin do
-    resources :users, only: [:index]
+    resources :users
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
   post '/login',   to: 'sessions#create'
   delete 'logout', to: 'sessions#destroy'
   namespace :admin do
-    resources :users
+    resources :users, only: [:index, :new, :create, :edit, :update, :destroy]
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,8 +14,8 @@ end
 
 10.times do |i|
   User.create(
-    name: Faker::Internet.user_name,
-    password:  Faker::Internet.password,
+    name: Faker::Internet.user_name(5..25),
+    password:  Faker::Internet.password(8..100),
     role: Faker::Number.between(0, 1)
   )
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -21,7 +21,7 @@ describe 'タスク' do
       fill_in I18n.t('views.task.label.due_at'), with: '2020/01/01 00:00'
       select '完了', from: I18n.t('views.task.label.status')
       select '', from: I18n.t('views.task.label.priority')
-      click_button I18n.t('views.task.button.submit')
+      click_button I18n.t('views.button.submit')
       expect(Task.exists?(user_id: user.id)).to be true
       expect(page).to have_content title
     end
@@ -33,7 +33,7 @@ describe 'タスク' do
       fill_in I18n.t('views.task.label.due_at'), with: '2020/01/01 00:00'
       select '完了', from: I18n.t('views.task.label.status')
       select '', from: I18n.t('views.task.label.priority')
-      click_button I18n.t('views.task.button.submit')
+      click_button I18n.t('views.button.submit')
       expect(page).to have_content I18n.t('views.task.message.created')
     end
   end
@@ -43,7 +43,7 @@ describe 'タスク' do
     it '加えた変更を更新すること' do
       visit edit_task_path(task.id)
       fill_in I18n.t('views.task.label.title'), with: title_edited
-      click_button I18n.t('views.task.button.submit')
+      click_button I18n.t('views.button.submit')
       expect(Task.exists?(user_id: user.id, title: title_edited)).to be true
       expect(page).to have_content title_edited
     end
@@ -51,7 +51,7 @@ describe 'タスク' do
     it '更新完了のフラッシュメッセージを表示すること' do
       visit edit_task_path(task.id)
       fill_in I18n.t('views.task.label.title'), with: '変更タスク'
-      click_button I18n.t('views.task.button.submit')
+      click_button I18n.t('views.button.submit')
       expect(page).to have_content I18n.t('views.task.message.updated')
     end
   end
@@ -88,7 +88,7 @@ describe 'タスク' do
     it '終了期限が近いタスクが上に来ること' do
       visit tasks_path
       select I18n.t('views.task.sort.due_at'), from: 'sort'
-      click_button I18n.t('views.task.button.search')
+      click_button I18n.t('views.button.search')
       expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(approaching_task.id))
       expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(not_approaching_task.id))
     end
@@ -100,7 +100,7 @@ describe 'タスク' do
     it '作成日時が新しいタスクが上に来ること' do
       visit tasks_path
       select I18n.t('views.task.sort.created_at'), from: 'sort'
-      click_button I18n.t('views.task.button.search')
+      click_button I18n.t('views.button.search')
       expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(new_task.id))
       expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(old_task.id))
     end
@@ -112,7 +112,7 @@ describe 'タスク' do
     it '優先順が高いタスクが上に来ること' do
       visit tasks_path
       select I18n.t('views.task.sort.priority_desc'), from: 'sort'
-      click_button I18n.t('views.task.button.search')
+      click_button I18n.t('views.button.search')
       expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(high_priority_task.id))
       expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(low_priority_task.id))
     end
@@ -120,7 +120,7 @@ describe 'タスク' do
     it '優先順が低いタスクが上に来ること' do
       visit tasks_path
       select I18n.t('views.task.sort.priority_asc'), from: 'sort'
-      click_button I18n.t('views.task.button.search')
+      click_button I18n.t('views.button.search')
       expect(page.all('tbody tr')[0]).to have_link('編集', href: edit_task_path(low_priority_task.id))
       expect(page.all('tbody tr')[1]).to have_link('編集', href: edit_task_path(high_priority_task.id))
     end
@@ -131,14 +131,14 @@ describe 'タスク' do
     it '入力された文字列でタスクを検索できること' do
       visit tasks_path
       fill_in :search, with: test_title
-      click_button I18n.t('views.task.button.search')
+      click_button I18n.t('views.button.search')
       expect(page).to have_content test_title
     end
 
     it 'マッチするものがない場合、マッチするものがなかったことを知らせること' do
       visit tasks_path
       fill_in :search, with: 'サンプル'
-      click_button I18n.t('views.task.button.search')
+      click_button I18n.t('views.button.search')
       expect(page).to have_content I18n.t('views.task.message.no_match_task')
     end
   end
@@ -147,7 +147,7 @@ describe 'タスク' do
     it '指定したステータスを持つタスクを検索すること' do
       visit tasks_path
       select I18n.t('enums.task.status.doing'), from: 'status'
-      click_button I18n.t('views.task.button.search')
+      click_button I18n.t('views.button.search')
       searched_task = Task.search_by_status('doing')
       expect(page.all('tbody tr').count).to eq searched_task.count
     end
@@ -158,7 +158,7 @@ describe 'タスク' do
       visit tasks_path
       fill_in 'search', with: test_title
       select I18n.t('enums.task.status.doing'), from: 'status'
-      click_button I18n.t('views.task.button.search')
+      click_button I18n.t('views.button.search')
       searched_task = Task.search_by_title(test_title).search_by_status('doing')
       expect(page.all('tbody tr').count).to eq searched_task.count
     end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe '管理画面' do
   describe '管理者ユーザー' do
     let!(:admin_user) { create(:admin) }
+    let(:user_name) { 'user_name' }
     before do
       visit login_path
       fill_in I18n.t('views.user.label.user_name'), with: admin_user.name
@@ -18,6 +19,71 @@ describe '管理画面' do
       expect(page).to have_content I18n.t('views.header.link.admin_page')
       click_link I18n.t('views.header.link.admin_page')
       expect(page).to have_content 'ユーザー 一覧'
+    end
+
+    context '新規のユーザーを作成するとき' do
+      it 'ユーザーを作成できること' do
+        visit admin_users_path
+        click_link I18n.t('views.user.link_text.new')
+        fill_in I18n.t('views.user.label.user_name'), with: user_name
+        fill_in I18n.t('views.user.label.password'), with: 'password'
+        select '管理者', from: I18n.t('views.user.label.role')
+        click_button I18n.t('views.button.submit')
+        expect(User.exists?(name: user_name)).to be true
+        expect(page).to have_content user_name
+      end
+
+      it '作成完了のフラッシュメッセージを表示すること' do
+        visit admin_users_path
+        click_link I18n.t('views.user.link_text.new')
+        fill_in I18n.t('views.user.label.user_name'), with: user_name
+        fill_in I18n.t('views.user.label.password'), with: 'password'
+        select '管理者', from: I18n.t('views.user.label.role')
+        click_button I18n.t('views.button.submit')
+        expect(page).to have_content I18n.t('views.user.message.created')
+      end
+    end
+
+    context 'ユーザーのロールを変更するとき' do
+      let!(:user) { create(:user) }
+      it 'ロールを変更できること' do
+        visit admin_users_path
+        click_link I18n.t('views.user.link_text.edit'), href: edit_admin_user_path(user)
+        select '一般', from: I18n.t('views.user.label.role')
+        click_button I18n.t('views.button.submit')
+        expect(User.find(user.id).role).to eq 'common'
+        expect(page.find('tr', text: "#{user.name}")).to have_content I18n.t('enums.user.role.common')
+      end
+
+      it '変更完了のフラッシュメッセージを表示すること' do
+        visit admin_users_path
+        click_link I18n.t('views.user.link_text.edit'), href: edit_admin_user_path(user)
+        select '一般', from: I18n.t('views.user.label.role')
+        click_button I18n.t('views.button.submit')
+        expect(page).to have_content I18n.t('views.user.message.updated')
+      end
+    end
+
+    context '既存のユーザーを削除するとき' do
+      let!(:user) { create(:user) }
+      it 'ユーザーを削除できること' do
+        visit admin_users_path
+        click_link I18n.t('views.user.link_text.delete'), href: admin_user_path(user)
+        expect(User.exists?(name: user.name)).not_to be true
+        expect(page).not_to have_content user.name
+      end
+
+      it '削除完了のフラッシュメッセージを表示すること' do
+        visit admin_users_path
+        click_link I18n.t('views.user.link_text.delete'), href: admin_user_path(user)
+        expect(page).to have_content I18n.t('views.user.message.deleted')
+      end
+
+      it '削除されたユーザーが持つタスクも削除されること' do
+        visit admin_users_path
+        click_link I18n.t('views.user.link_text.delete'), href: admin_user_path(user)
+        expect(Task.exists?(user_id: user.id)).not_to be true
+      end
     end
   end
 

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -78,12 +78,6 @@ describe '管理画面' do
         click_link I18n.t('views.user.link_text.delete'), href: admin_user_path(user)
         expect(page).to have_content I18n.t('views.user.message.deleted')
       end
-
-      it '削除されたユーザーが持つタスクも削除されること' do
-        visit admin_users_path
-        click_link I18n.t('views.user.link_text.delete'), href: admin_user_path(user)
-        expect(Task.exists?(user_id: user.id)).not_to be true
-      end
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,79 @@
 require 'rails_helper'
 
-RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe 'User' do
+  describe '#name'do
+    let(:user) { build(:user) }
+    let(:other_user) { create(:user) }
+    it '正常に保存ができること' do
+      expect(user).to be_valid
+    end
+
+    it '空欄のとき、保存ができないこと' do
+      user.name = ''
+      user.valid?
+      expect(user.errors.details[:name].any? { |e| e[:error] == :blank }).to be true
+    end
+
+    it '同じ文字列を name に持つユーザーがいた場合、保存ができないこと' do
+      user.name = other_user.name
+      user.valid?
+      expect(user.errors.details[:name].any? { |e| e[:error] == :taken }).to be true
+    end
+
+    it '大文字<->小文字の違いでも、同じ文字列の name だと保存ができないこと' do
+      user.name = other_user.name.upcase
+      user.valid?
+      expect(user.errors.details[:name].any? { |e| e[:error] == :taken }).to be true
+    end
+
+    it '4文字以下だと保存ができないこと' do
+      user.name = 'a' * 4
+      user.valid?
+      expect(user.errors.details[:name].any? { |e| e[:error] == :too_short }).to be true
+    end
+
+    it '26文字以上だと保存ができないこと' do
+      user.name = 'a' * 26
+      user.valid?
+      expect(user.errors.details[:name].any? { |e| e[:error] == :too_long }).to be true
+    end
+  end
+
+  describe '#password' do
+    let(:user) { build(:user, password: '') }
+    it '正常に保存ができること' do
+      user.password = 'password'
+      expect(user).to be_valid
+    end
+
+    it '空欄のとき、保存ができないこと' do
+      user.valid?
+      expect(user.errors.details[:password].any? { |e| e[:error] == :blank }).to be true
+    end
+
+    it '7文字以下だと保存ができないこと' do
+      user.password = 'a' * 7
+      user.valid?
+      expect(user.errors.details[:password].any? { |e| e[:error] == :too_short }).to be true
+    end
+
+    it '101文字以上だと保存ができないこと' do
+      user.password = 'a' * 101
+      user.valid?
+      expect(user.errors.details[:password].any? { |e| e[:error] == :too_long }).to be true
+    end
+  end
+
+  describe '#role' do
+    let(:user) { build(:user) }
+    it '正常に保存ができること' do
+      expect(user).to be_valid
+    end
+
+    it '空欄のとき、保存ができないこと' do
+      user.role = ''
+      user.valid?
+      expect(user.errors.details[:role].any? { |e| e[:error] == :blank }).to be true
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -70,4 +70,12 @@ describe 'User' do
       expect(user.errors.details[:role].any? { |e| e[:error] == :blank }).to be true
     end
   end
+
+  context 'ユーザーを削除したとき' do
+    let(:user) { create(:user)}
+    it '削除されたユーザーが持つタスクも削除されること' do
+      user.destroy
+      expect(Task.exists?(user_id: user.id)).not_to be true
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,12 +26,6 @@ describe 'User' do
       expect(user.errors.details[:name].any? { |e| e[:error] == :taken }).to be true
     end
 
-    it '4文字以下だと保存ができないこと' do
-      user.name = 'a' * 4
-      user.valid?
-      expect(user.errors.details[:name].any? { |e| e[:error] == :too_short }).to be true
-    end
-
     it '26文字以上だと保存ができないこと' do
       user.name = 'a' * 26
       user.valid?


### PR DESCRIPTION
## 何をやったか

【このPRで**やった**こと】
ユーザーの管理画面で、ユーザーの新規作成・編集・削除ができるようにしました。

- ユーザー名は5文字以上25文字以内で設定することができ、大文字小文字を区別しません。
- パスワードは8文字以上100文字以内で設定することができます。
- ユーザー情報のうち、本人以外が編集できるのはロールのみです（他者のユーザー名とパスワードを管理者であるユーザーが変更できるようにしてしまうと、ログインに必要な情報が変更されることになり、本人の同意なく変更されたりした場合そのユーザーがログインできなくなってしまうため）
    - そのため、ユーザー名とパスワードのバリデーションはユーザーが作成されるタイミングのみ検証します。
- ユーザーが削除された場合、そのユーザーが持つタスクも一緒に削除されます。

【このPRで**やらない**こと】
以下は、今後のPRで実装します。
- ユーザが作成したタスクの一覧が見られるようにする。

👇 **新規作成ページ**
![image](https://user-images.githubusercontent.com/14156156/45144620-98015f80-b1f9-11e8-803e-9203ee6a6337.png)

👇 **編集ページ**
![image](https://user-images.githubusercontent.com/14156156/45145016-94220d00-b1fa-11e8-9899-ee768da246fb.png)

👇 **すでに存在する name で登録しようとしたとき**
![image](https://user-images.githubusercontent.com/14156156/45145127-e19e7a00-b1fa-11e8-946a-3c6d982648e5.png)

## レビューポイント
- 余計なインデント、スペースがないか
- ユーザーの新規作成・編集・削除などの処理が正しく書けているかどうか
- テストが正しく書けているかどうか
- 無駄な記述の仕方をしていないか

## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:
