### PR TITLE
管理ユーザが1人もいなくならないようにした

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -33,8 +33,11 @@ class Admin::UsersController < ApplicationController
 
   def destroy
     @user = User.find(params[:id])
-    @user.destroy
-    redirect_to admin_users_path, flash: { success: t('views.user.message.deleted') }
+    if @user.destroy
+      redirect_to admin_users_path, flash: { success: t('views.user.message.deleted') }
+    else
+      redirect_to admin_users_path, flash: { danger: t('views.user.message.last_admin') }
+    end
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,14 @@
 class User < ApplicationRecord
   has_secure_password
+  before_destroy :last_admin
   has_many :tasks, dependent: :destroy
   enum role: { common: 0, admin: 1 }
 
   validates :name, presence: true, length: { minimum: 1, maximum: 25 }, uniqueness: { case_sensitive: false }, on: :create
   validates :password, presence: true, length: { minimum:8, maximum: 100 }, on: :create
   validates :role, presence: true
+
+  def last_admin
+    throw :abort if User.admin.count == 1 && self.admin?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   has_secure_password
-  before_destroy :last_admin
+  before_destroy :cansel_destroy_last_admin
   has_many :tasks, dependent: :destroy
   enum role: { common: 0, admin: 1 }
 
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   validates :password, presence: true, length: { minimum:8, maximum: 100 }, on: :create
   validates :role, presence: true
 
-  def last_admin
+  def cansel_destroy_last_admin
     throw :abort if User.admin.count == 1 && self.admin?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   has_secure_password
-  before_destroy :cansel_destroy_last_admin
+  before_destroy :cancel_destroy_last_admin
   has_many :tasks, dependent: :destroy
   enum role: { common: 0, admin: 1 }
 
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   validates :password, presence: true, length: { minimum:8, maximum: 100 }, on: :create
   validates :role, presence: true
 
-  def cansel_destroy_last_admin
+  def cancel_destroy_last_admin
     throw :abort if User.admin.count == 1 && self.admin?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
         updated: "Updated a user"
         deleted: "Deleted a user"
         delete_confirm: "Are you sure you want to delte this task?"
+        last_admin: "At least one administrator account is required"
       link_text:
         new: "New"
         edit: "Edit"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -73,6 +73,7 @@ ja:
         updated: "ロールを更新しました"
         deleted: "ユーザーを削除しました"
         delete_confirm: "本当に削除しますか？"
+        last_admin: "管理者アカウントは最低1つ必要です"
       link_text:
         new: "新規ユーザーを作成"
         edit: "編集"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     password 'password'
     role 1
 
-    factory :admin do
+    factory :admin_user do
       sequence(:name) { |n| "admin_user#{n}"}
       password 'password'
       role 1

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -79,6 +79,15 @@ describe '管理画面' do
         expect(page).to have_content I18n.t('views.user.message.deleted')
       end
     end
+
+    context '1人しかいない管理者ユーザーを削除するとき' do
+      it '削除できないようにすること' do
+        visit admin_users_path
+        click_link I18n.t('views.user.link_text.delete'), href: admin_user_path(admin_user)
+        expect(User.exists?(name: admin_user.name)).to be true
+        expect(page).to have_content I18n.t('views.user.message.last_admin')
+      end
+    end
   end
 
   describe '一般ユーザー' do

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe '管理画面' do
   describe '管理者ユーザー' do
-    let!(:admin_user) { create(:admin) }
+    let!(:admin_user) { create(:admin_user) }
     let(:user_name) { 'user_name' }
     before do
       visit login_path

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,9 +73,15 @@ describe 'User' do
 
   context 'ユーザーを削除したとき' do
     let(:user) { create(:user)}
+    let(:admin_user) { create(:admin_user) }
     it '削除されたユーザーが持つタスクも削除されること' do
       user.destroy
       expect(Task.exists?(user_id: user.id)).not_to be true
+    end
+
+    it '最後の管理者ユーザーを削除した場合は削除されないこと' do
+      admin_user.destroy
+      expect(User.exists?(id: admin_user.id)).to be true
     end
   end
 end


### PR DESCRIPTION
## 何をやったか
[ステップ22](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9722-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AB%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86)の、

> 管理ユーザが1人もいなくならないように削除の制御をしましょう

を実装しました。

【このPRで**やった**こと】
- 管理者が1人しかいない状態でその管理者ユーザーを削除できません。
- 削除しようとすると、フラッシュメッセージで削除ができないことをお知らせします

【このPRで**やらない**こと】
- ユーザに管理ユーザと一般ユーザを区別する
  - すでに実装済
- 一般ユーザが管理画面にアクセスした場合、専用の例外を出す
  - 別のPRでやります
- 例外を補足して、適切にエラーページを表示する
    - 別のPRでやります
- ユーザ管理画面でロールを選択できるようにする
    - すでに実装済

👇 **管理者が1人しかいない状態**
![image](https://user-images.githubusercontent.com/14156156/45464189-6f71ec00-b74a-11e8-9207-a940ac060e20.png)

👇 **削除しようとするとフラッシュメッセージが出ます**
![image](https://user-images.githubusercontent.com/14156156/45464203-7d277180-b74a-11e8-957a-5ea6e5654517.png)

（「管理者アカウントは最低1つ必要です」って日本語が下手な感じがしていますが、頑張って考えたけどこれしか浮かびませんでした）

## レビューポイント
- 余計なインデント、スペースがないか
- 管理ユーザが1人もいなくならないようにする処理が正しく書けているかどうか
- テストが正しく書けているかどうか
- 無駄な記述の仕方をしていないか

## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:
