### PR TITLE
一般ユーザーが管理画面にアクセスしたとき、エラーページを表示する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
     end
 
     def reject_common_access
-      redirect_to root_path, flash: { warning: '管理者以外はアクセスできません' } unless current_user&.admin?
+      render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html' unless current_user&.admin?
     end
 
     def reject_visitor_access

--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>The page you were looking for doesn't exist (404)</title>
+  <title>ページが見つかりません</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
@@ -13,8 +13,8 @@
   }
 
   .rails-default-error-page div.dialog {
-    width: 95%;
-    max-width: 33em;
+    width: 100%;
+    max-width: 40em;
     margin: 4em auto 0;
   }
 
@@ -24,15 +24,14 @@
     border-left-color: #999;
     border-bottom-color: #BBB;
     border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
+    border-radius: 9px;
     background-color: white;
-    padding: 7px 12% 0;
+    padding: 7px 0;
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
   .rails-default-error-page h1 {
-    font-size: 100%;
+    font-size: 120%;
     color: #730E15;
     line-height: 1.5em;
   }
@@ -58,10 +57,9 @@
   <!-- This file lives in public/404.html -->
   <div class="dialog">
     <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+      <h1>ページが見つかりません(Error:404)</h1>
+      <p>お探しのページは削除されたか、URLが変更になっている可能性があります。</p>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
   </div>
 </body>
 </html>

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -94,9 +94,9 @@ describe '管理画面' do
       expect(page).not_to have_content I18n.t('views.header.link.admin_page')
     end
 
-    it 'ユーザー 一覧ページにアクセスできないこと' do
+    it '管理画面にアクセスすると404ページが表示されること' do
       visit admin_users_path
-      expect(page).not_to have_content 'ユーザー 一覧'
+      expect(page).to have_content 'ページが見つかりません'
     end
   end
 end


### PR DESCRIPTION
## 何をやったか
[ステップ22](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9722-%E3%83%A6%E3%83%BC%E3%82%B6%E3%81%AB%E3%83%AD%E3%83%BC%E3%83%AB%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%82%88%E3%81%86)の、

> 一般ユーザが管理画面にアクセスした場合、専用の例外を出してみましょう
> 例外を補足して、適切にエラーページを表示しましょう

を実装しました。

- 一般ユーザーが管理画面にアクセスした場合、404エラーページが表示されます。
    - 401 などの認証エラーにすると、そのURLが権限が必要な管理画面であることが推測されてしまうため、404にしました。
- `404.html`  は、Railsが生成したデフォルトのページを再利用しています。


## レビューポイント
- 余計なインデント、スペースがないか
- 一般ユーザーが管理画面にアクセスしたとき、エラーページを表示する処理が正しく書けているかどうか
- テストが正しく書けているかどうか
- 無駄な記述の仕方をしていないか

## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:
