### PR TITLE
ラベルを編集・削除できるようにした

### DIFF
--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -18,6 +18,23 @@ class LabelsController < ApplicationController
       render :new
     end
   end
+
+  def edit
+  end
+
+  def update
+    if @label.update(label_params)
+      redirect_to labels_path, flash: { success: t('views.label.message.updated') }
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @label.destroy
+      redirect_to labels_path, flash: { success: t('views.label.message.deleted') }
+  end
+
   private
 
   def label_params

--- a/app/views/labels/edit.html.slim
+++ b/app/views/labels/edit.html.slim
@@ -1,3 +1,3 @@
 div.text-center
-  h1 = t('views.label.title.new')
+  h1 = t('views.label.title.edit')
 = render 'form'

--- a/app/views/labels/index.html.slim
+++ b/app/views/labels/index.html.slim
@@ -14,8 +14,8 @@ div.row
           - @labels.each do |label|
             tr
               td = label.name
-              td = link_to t('views.user.link_text.edit'), edit_label_path(label.id)
-              td = link_to t('views.user.link_text.delete'), label_path(label.id), method: :delete, data: {confirm: t('views.label.message.delete_confirm')}, class: 'delete-link'
+              td = link_to t('views.label.link_text.edit'), edit_label_path(label.id)
+              td = link_to t('views.label.link_text.delete'), label_path(label.id), method: :delete, data: {confirm: t('views.label.message.delete_confirm')}, class: 'delete-link'
       - else
         div = t('views.task.message.no_match_task')
     = paginate @labels

--- a/app/views/labels/index.html.slim
+++ b/app/views/labels/index.html.slim
@@ -17,5 +17,5 @@ div.row
               td = link_to t('views.label.link_text.edit'), edit_label_path(label.id)
               td = link_to t('views.label.link_text.delete'), label_path(label.id), method: :delete, data: {confirm: t('views.label.message.delete_confirm')}, class: 'delete-link'
       - else
-        div = t('views.task.message.no_match_task')
+        div = t('views.label.message.no_match_label')
     = paginate @labels

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -87,6 +87,8 @@ en:
       label:
         name: "Label name"
       link_text:
+        edit: "Edit"
+        delete: "Delete"
         back: "Back"
       message:
         no_match_label: "There is no matching label"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,7 +72,7 @@ en:
         created: "Created a new user"
         updated: "Updated a user"
         deleted: "Deleted a user"
-        delete_confirm: "Are you sure you want to delte this task?"
+        delete_confirm: "Are you sure you want to delte this user?"
         last_admin: "At least one administrator account is required"
       link_text:
         new: "New"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,9 @@ en:
       message:
         no_match_label: "There is no matching label"
         created: "Created a new label"
+        upadted: "Updated a lebel"
+        deleted: "Deleted a label"
+        delete_confirm: "Are you sure you want to delte this label?"
   activerecord:
     errors:
       messages:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -83,7 +83,8 @@ ja:
     label:
       title:
         list_of_labels: "ラベル一覧"
-        new: "新規ラベルを作成"
+        new: "ラベルを作成する"
+        edit: "ラベルを編集する"
       label:
         name: "ラベル名"
       link_text:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -87,6 +87,8 @@ ja:
       label:
         name: "ラベル名"
       link_text:
+        edit: "編集"
+        delete: "削除"
         back: "戻る"
       message:
         no_match_label: "該当するラベルはありません"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -90,6 +90,9 @@ ja:
       message:
         no_match_label: "該当するラベルはありません"
         created: "ラベルを作成しました"
+        updated: "ラベルを更新しました"
+        deleted: "ラベルを削除しました"
+        delete_confirm: "本当に削除しますか？"
   activerecord:
     errors:
       messages:

--- a/spec/features/labels_spec.rb
+++ b/spec/features/labels_spec.rb
@@ -31,7 +31,7 @@ describe 'ラベル' do
   end
 
   context '既存のラベルを更新するとき' do
-    let(:label) { create(:label) }
+    let!(:label) { create(:label, user_id: user.id) }
     it '加えた変更を更新すること' do
       visit edit_label_path(label.id)
       fill_in I18n.t('views.label.label.name'), with: label_name_edited
@@ -49,7 +49,7 @@ describe 'ラベル' do
   end
 
   context '既存のタスクを削除するとき' do
-    let(:label) { create(:label) }
+    let!(:label) { create(:label, user_id: user.id) }
     it 'ラベルを削除できること' do
       visit labels_path
       click_link I18n.t('views.label.link_text.delete')

--- a/spec/features/labels_spec.rb
+++ b/spec/features/labels_spec.rb
@@ -3,6 +3,7 @@ require 'kaminari'
 
 describe 'ラベル' do
   let(:label_name) { 'Label' }
+  let(:label_name_edited) { 'Label_edited' }
   let!(:user) { create(:user) }
   before do
     visit '/login'
@@ -26,6 +27,40 @@ describe 'ラベル' do
       click_button I18n.t('views.button.submit')
       expect(Label.exists?(user_id: user.id)).to be true
       expect(page).to have_content I18n.t('views.label.message.created')
+    end
+  end
+
+  context '既存のラベルを更新するとき' do
+    let(:label) { create(:label) }
+    it '加えた変更を更新すること' do
+      visit edit_label_path(label.id)
+      fill_in I18n.t('views.label.label.name'), with: label_name_edited
+      click_button I18n.t('views.button.submit')
+      expect(Label.exists?(name: label_name_edited)).to be true
+      expect(page).to have_content label_name_edited
+    end
+
+    it '更新完了のフラッシュメッセージを表示すること' do
+      visit edit_label_path(label.id)
+      fill_in I18n.t('views.label.label.name'), with: label_name_edited
+      click_button I18n.t('views.button.submit')
+      expect(page).to have_content I18n.t('views.label.message.updated')
+    end
+  end
+
+  context '既存のタスクを削除するとき' do
+    let(:label) { create(:label) }
+    it 'ラベルを削除できること' do
+      visit labels_path
+      click_link I18n.t('views.label.link_text.delete')
+      expect(Label.exists?(name: label.name)).not_to be true
+      expect(page).not_to have_content label.name
+    end
+
+    it '削除完了のフラッシュメッセージを表示すること' do
+      visit labels_path
+      click_link I18n.t('views.label.link_text.delete')
+      expect(page).to have_content I18n.t('views.label.message.deleted')
     end
   end
 end


### PR DESCRIPTION
## 何をやったか
ラベルを編集・削除できるようにしました。
ラベル一覧ページにある「編集」「削除」リンクより編集・削除ができます。

【このPRで**やらない**こと】

- タスクにラベルを設定できるようにする

👇 ラベル編集ページ
![image](https://user-images.githubusercontent.com/14156156/45998926-43a61d00-c0df-11e8-8314-71fa63e2a951.png)

👇 ラベル削除後
![image](https://user-images.githubusercontent.com/14156156/45998960-5882b080-c0df-11e8-87cd-4ae1ee4cae6d.png)

## レビューポイント
- 余計なインデント、スペースがないか
- ラベルを編集・削除する処理が正しく書けているかどうか
- テストが正しく書けているかどうか
- 無駄な記述の仕方をしていないか

## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:
