### PR TITLE
タスクをラベルで検索できるようにする

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,7 +5,7 @@ class TasksController < ApplicationController
   def index
     @statuses = Task.statuses.map { |k, v| [t("enums.task.status.#{k}"), v]}
     @sorts = [t('views.task.sort.created_at'), 0], [t('views.task.sort.due_at'), 1], [t('views.task.sort.priority_desc'), 2], [t('views.task.sort.priority_asc'), 3]
-    @tasks = @current_user.tasks.search_by_title(params[:search]).search_by_status(params[:status]).order_by(params[:sort]).page(params[:page])
+    @tasks = @current_user.tasks.search_by_title(params[:search]).search_by_status(params[:status]).order_by(params[:sort]).search_by_labels(params[:label_ids]).page(params[:page])
   end
 
   def new

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -20,4 +20,7 @@ class Task < ApplicationRecord
       end
     order(option)
   }
+  scope :search_by_labels, -> label_ids {
+    joins(:task_labels).where(task_labels: { label_id: label_ids }).distinct if label_ids.present?
+  }
 end

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -44,7 +44,7 @@ div.row
         - @labels.each do |l|
           div.form-control.my-2
             = check_box_tag 'label_ids[]', l.id
-            = label_tag l.name
+            = label_tag :label_ids_, l.name
       div.form-group
         label.small ソートする
         = select_tag :sort, options_for_select(@sorts), class: 'form-control'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -35,6 +35,12 @@ div.row
         label.small ステータスで絞り込み
         = select_tag :status, options_for_select(@statuses), prompt: 'ステータス（未選択）', class: 'form-control'
       div.form-group
+        label.small ラベルで絞り込み
+        = collection_check_boxes @labels, :label_ids, @labels, :id, :name do |b|
+          div.form-control.my-2
+            = b.check_box
+            = b.label { b.text }
+      div.form-group
         label.small ソートする
         = select_tag :sort, options_for_select(@sorts), class: 'form-control'
       div.form-group = submit_tag t('views.button.search'), class: 'btn btn-outline-secondary'

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -35,11 +35,12 @@ div.row
         label.small ステータスで絞り込み
         = select_tag :status, options_for_select(@statuses), prompt: 'ステータス（未選択）', class: 'form-control'
       div.form-group
+        div
         label.small ラベルで絞り込み
-        = collection_check_boxes @labels, :label_ids, @labels, :id, :name do |b|
+        - @labels.each do |l|
           div.form-control.my-2
-            = b.check_box
-            = b.label { b.text }
+            = check_box_tag 'label_ids[]', l.id
+            = label_tag l.name
       div.form-group
         label.small ソートする
         = select_tag :sort, options_for_select(@sorts), class: 'form-control'

--- a/spec/factories/labels.rb
+++ b/spec/factories/labels.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :label do
-    sequence(:name) { |n| "Label#{n}"}
+    sequence(:name) { |n| "Label#{n}" }
   end
 end

--- a/spec/factories/labels.rb
+++ b/spec/factories/labels.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :label do
-    user { create(:user) }
     sequence(:name) { |n| "Label#{n}"}
   end
 end

--- a/spec/factories/labels.rb
+++ b/spec/factories/labels.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :label do
-    name { "Label1" }
     user { create(:user) }
+    sequence(:name) { |n| "Label#{n}"}
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -153,6 +153,19 @@ describe 'タスク' do
     end
   end
 
+  context 'タスクをラベルで検索するとき' do
+    before do
+      has_labels_task = create(:task, user_id: user.id)
+      labels = create_list(:label, 2, tasks:[has_labels_task], user_id: user.id)
+    end
+    it '指定したラベルを持つタスクを検索すること' do
+      visit tasks_path
+      check 'label_ids_', match: :first
+      searched_task = Task.search_by_labels(user.tasks.first.labels)
+      expect(page.all('tbody tr').count).to eq searched_task.count
+    end
+  end
+
   context 'タイトルとステータスで検索するとき' do
     it '指定したタイトルとステータスを持つタスクを検索すること' do
       visit tasks_path

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -153,12 +153,12 @@ describe 'タスク' do
     end
   end
 
-  context 'タスクをラベルで検索するとき' do
+  context 'タスクをラベルで絞り込むとき' do
     before do
       has_labels_task = create(:task, user_id: user.id)
       labels = create_list(:label, 2, tasks:[has_labels_task], user_id: user.id)
     end
-    it '指定したラベルを持つタスクを検索すること' do
+    it '指定したラベルを含んでいるタスクがすべて表示されること' do
       visit tasks_path
       check 'label_ids_', match: :first
       searched_task = Task.search_by_labels(user.tasks.first.labels)

--- a/spec/models/label_spec.rb
+++ b/spec/models/label_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 describe 'Label' do
   describe '#name' do
-    let(:label) { build(:label) }
+    let(:user) { create(:user) }
+    let(:label) { build(:label, user_id: user.id) }
     it '正常に保存できること' do
       expect(label).to be_valid
     end

--- a/spec/models/task_label_spec.rb
+++ b/spec/models/task_label_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 describe 'TaskLabel' do
-  let!(:label) { create(:label) }
+  let!(:user) { create(:user) }
+  let!(:label) { create(:label, user_id: user.id) }
   let!(:task) { create(:task, label_ids: [label.id]) }
   it '重複したレコードが保存できないこと' do
     other_task = Task.new(id: task.id, user_id: task.user_id, title: task.title, label_ids: [task.labels.last.id])

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -56,5 +56,16 @@ describe 'Task' do
         expect(Task.search_by_status('todo')).not_to include(not_come_up_task)
       end
     end
+
+    context '#search_by_labels' do
+      let!(:user) { create(:user) }
+      let!(:no_labels_task) { create(:task) }
+      let!(:has_labels_task) { create(:task, user_id: user.id) }
+      let!(:labels) { create_list(:label, 2, tasks:[has_labels_task], user_id: user.id) }
+      it '指定されたラベルのタスクを返す' do
+        expect(Task.search_by_labels(has_labels_task.labels)).to include(has_labels_task)
+        expect(Task.search_by_labels(has_labels_task.labels)).not_to include(no_labels_task)
+      end
+    end
   end
 end


### PR DESCRIPTION
## 何をやったか
タスクをラベルで絞り込みできるようにします。
検索時に指定したラベルを含むタスクを取得し、表示します。

👇 トップページでラベルを選択して検索しようとしている様子
![image](https://user-images.githubusercontent.com/14156156/46138798-d681bb80-c287-11e8-8342-b35340d3bf9e.png)

👇 指定したラベルを含むタスクが表示されている様子
![image](https://user-images.githubusercontent.com/14156156/46138824-ea2d2200-c287-11e8-94c4-bd35086fe3e8.png)

## レビューポイント
- 余計なインデント、スペースがないか
- タスクをラベルで検索する処理が正しく書けているかどうか
- テストが正しく書けているかどうか
- 無駄な記述の仕方をしていないか

## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:
