### PR TITLE
エラーページを設定する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
 
   def render_500(e = nil)
     if e
-      logger.error e
+      logger.error e.inspect
       logger.error e.backtrace.join("\n")
     end
     render file: Rails.root.join('public/500.html'), status: 500, layout: false, content_type: 'text/html'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
 
   def render_404(e = nil)
     if e
-      logger.error e
+      logger.error e.inspect
       logger.error e.backtrace.join("\n")
     end
     render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,18 +6,18 @@ class ApplicationController < ActionController::Base
   helper_method :logged_in?
   before_action :set_locale
 
-  def render_404(e = nil)
-    if e
-      logger.error e.inspect
-      logger.error e.backtrace.join("\n")
+  def render_404(error = nil)
+    if error
+      logger.error error.inspect
+      logger.error error.backtrace.join("\n")
     end
     render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html'
   end
 
-  def render_500(e = nil)
-    if e
-      logger.error e.inspect
-      logger.error e.backtrace.join("\n")
+  def render_500(error = nil)
+    if error
+      logger.error error.inspect
+      logger.error error.backtrace.join("\n")
     end
     render file: Rails.root.join('public/500.html'), status: 500, layout: false, content_type: 'text/html'
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,26 @@
 class ApplicationController < ActionController::Base
+  rescue_from StandardError, with: :render_500 unless Rails.env.development?
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404 unless Rails.env.development?
+  rescue_from ActionController::RoutingError, with: :render_404 unless Rails.env.development?
   include Session
   helper_method :logged_in?
   before_action :set_locale
+
+  def render_404(e = nil)
+    if e
+      logger.error e
+      logger.error e.backtrace.join("\n")
+    end
+    render file: Rails.root.join('public/404.html'), status: 404, layout: false, content_type: 'text/html'
+  end
+
+  def render_500(e = nil)
+    if e
+      logger.error e
+      logger.error e.backtrace.join("\n")
+    end
+    render file: Rails.root.join('public/500.html'), status: 500, layout: false, content_type: 'text/html'
+  end
 
   private
   

--- a/public/500.html
+++ b/public/500.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>We're sorry, but something went wrong (500)</title>
+  <title>内部エラーが発生しました</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
@@ -13,7 +13,7 @@
   }
 
   .rails-default-error-page div.dialog {
-    width: 95%;
+    width: 100%;
     max-width: 33em;
     margin: 4em auto 0;
   }
@@ -24,15 +24,14 @@
     border-left-color: #999;
     border-bottom-color: #BBB;
     border-top: #B00100 solid 4px;
-    border-top-left-radius: 9px;
-    border-top-right-radius: 9px;
+    border-radius: 9px;
     background-color: white;
-    padding: 7px 12% 0;
+    padding: 7px 0;
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
   .rails-default-error-page h1 {
-    font-size: 100%;
+    font-size: 120%;
     color: #730E15;
     line-height: 1.5em;
   }
@@ -58,9 +57,12 @@
   <!-- This file lives in public/500.html -->
   <div class="dialog">
     <div>
-      <h1>We're sorry, but something went wrong.</h1>
+      <h1>内部エラーが発生しました(Error:500)</h1>
+    <p>
+      サーバ内部で一時的なエラーが発生しました。<br>
+      復旧までしばらくお待ちください。
+    </p>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## 何をやったか
[ステップ24](https://github.com/everyleaf/el-training/blob/master/docs/el-training.md#%E3%82%B9%E3%83%86%E3%83%83%E3%83%9724-%E3%82%A8%E3%83%A9%E3%83%BC%E3%83%9A%E3%83%BC%E3%82%B8%E3%82%92%E9%81%A9%E5%88%87%E3%81%AB%E8%A8%AD%E5%AE%9A%E3%81%97%E3%82%88%E3%81%86)の、
> - Railsが用意しているデフォルトのエラーページを自分が作った画面にしてみましょう
> - 状況に応じて、適切にエラーページを設定しましょう
>   - ステータスコードの404ページと500ページの2種類の設定は少なくとも必須とします

を実装しました。

404ページについては https://github.com/tsumichan/todo-app/pull/46 にて実装済です。


👇 500.html
![image](https://user-images.githubusercontent.com/14156156/46191537-e4404b00-c332-11e8-8a86-93b23ffe2649.png)

## レビューポイント
- 余計なインデント、スペースがないか
- エラーページを設定する処理が正しく書けているかどうか
- テストが正しく書けているかどうか
- 無駄な記述の仕方をしていないか

## レビュアー
@shiro16 さん、 @june29 さんどちらかは必須

その他どなたでもお願いします :pray:
