### PR TITLE
Factoryのlintで警告が出るので、書き方を変える

### DIFF
--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,26 +1,26 @@
 FactoryBot.define do
   factory :task do
-    title 'テスト用タスク'
-    description 'テスト用タスクです'
-    due_at Date.parse('2020-01-01')
-    status 'todo'
-    priority 'nothing'
+    title { 'テスト用タスク' }
+    description { 'テスト用タスクです' }
+    due_at { Date.parse('2020-01-01') }
+    status { 'todo' }
+    priority { 'nothing' }
     user { create(:user) }
 
     factory :new_task do
-      created_at Date.parse('2020-01-01')
+      created_at { Date.parse('2020-01-01') }
     end
 
     factory :old_task do
-      created_at Date.parse('2000-01-01')
+      created_at { Date.parse('2000-01-01') }
     end
 
     factory :high_priority_task do
-      priority 'high'
+      priority { 'high' }
     end
 
     factory :low_priority_task do
-      priority 'low'
+      priority { 'low' }
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,19 +1,19 @@
 FactoryBot.define do
   factory :user do
     sequence(:name) { |n| "user#{n}"}
-    password 'password'
-    role 1
+    password { 'password' }
+    role { 1 }
 
     factory :admin_user do
       sequence(:name) { |n| "admin_user#{n}"}
-      password 'password'
-      role 1
+      password { 'password' }
+      role { 1 }
     end
 
     factory :common_user do
       sequence(:name) { |n| "common_user#{n}"}
-      password 'password'
-      role 0
+      password { 'password' }
+      role { 0 }
     end
   end
 end


### PR DESCRIPTION
## 何をやったか

ファクトリの定義で警告が出ていたので、推奨される記法で記述するように修正します。

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

title { "テスト用タスク" }

To automatically update from static attributes to dynamic ones,
install rubocop-rspec and run:

rubocop \
  --require rubocop-rspec \
  --only FactoryBot/AttributeDefinedStatically \
  --auto-correct
```

警告文コピペして気がついたけど、 gem 入れたら一括でババっと置換してくれることに今気がついた…
## レビューポイント

## レビュアー

CI通ったらmergeしよ