### PR TITLE
.idea を .gitignore に追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# RubyMine
+.idea


### PR DESCRIPTION
## 何をやったか

RubyMine使っているとプロジェクト直下に `.idea`ってディレクトリができるらしい。
これはエディタの設定のためのものらしいので、バージョン管理しないようにする。